### PR TITLE
Item Revamp

### DIFF
--- a/TiTsEd/App.xaml.cs
+++ b/TiTsEd/App.xaml.cs
@@ -163,16 +163,21 @@ namespace TiTsEd
 
 
 #if DEBUG
-        static AmfFile AutoLoad(FlashDirectory[] directories)
-        {
-            var file = directories[0].Files[0];
+        static AmfFile AutoLoad(FlashDirectory[] directories) {
+            //find first file
+            AmfFile file = null;
+            foreach (var dir in directories) {
+                foreach (var dfile in dir.Files) {
+                    file = dfile;
+                    break;
+                }
+            }
 
             VM.Instance.Load(file.FilePath, SerializationFormat.Slot, createBackup: true);
             return file;
         }
 
-        static void PrintStatuses(AmfFile file)
-        {
+        static void PrintStatuses(AmfFile file) {
             foreach (AmfPair pair in file.GetObj("statusAffects"))
             {
                 int key = Int32.Parse(pair.Key as string);
@@ -181,12 +186,10 @@ namespace TiTsEd
             }
         }
 
-        static void RunSerializationTest(FlashDirectory[] directories)
-        {
+        static void RunSerializationTest(FlashDirectory[] directories) {
             Stopwatch s = new Stopwatch();
             s.Start();
-            foreach (var first in directories[0].Files)
-            {
+            foreach (var first in directories[0].Files) {
                 var outPath = "e:\\" + Path.GetFileName(first.FilePath);
                 first.TestSerialization();
                 first.Save(outPath, first.Format);

--- a/TiTsEd/Model/XmlData.cs
+++ b/TiTsEd/Model/XmlData.cs
@@ -98,8 +98,8 @@ namespace TiTsEd.Model {
         [XmlElement("Body")]
         public XmlBodySet Body { get; set; }
 
-        [XmlArray("Items"), XmlArrayItem("Item")]
-        public XmlItem[] Items { get; set; }
+        [XmlArray("Items"), XmlArrayItem("ItemType")]
+        public List<XmlItemType> ItemTypes { get; set; }
 
         [XmlArray("Perks"), XmlArrayItem("PerkGroup")]
         public List<XmlPerkGroup> PerkGroups { get; set; }
@@ -232,7 +232,6 @@ namespace TiTsEd.Model {
         [XmlArray, XmlArrayItem("VaginaFlag")]
         public XmlEnum[] VaginaFlags { get; set; }
 
-
         [XmlArray, XmlArrayItem("CockType")]
         public XmlEnum[] CockTypes { get; set; }
 
@@ -269,8 +268,20 @@ namespace TiTsEd.Model {
         }
     }
 
+    public sealed class XmlItemType {
+        [XmlAttribute]
+        public string Name { get; set; }
+
+        [XmlElement("Item")]
+        public List<XmlItem> Items { get; set; }
+
+        public override string ToString() {
+            return Name;
+        }
+    }
+
     public sealed class XmlItem {
-        public static XmlItem Empty = new XmlItem("classes.Items.Miscellaneous::EmptySlot", "<empty>", "Other", 0);
+        public static XmlItem Empty = new XmlItem("classes.Items.Miscellaneous::EmptySlot", "<empty>", 0);
 
         [XmlAttribute]
         public string ID { get; set; }
@@ -281,18 +292,15 @@ namespace TiTsEd.Model {
         [XmlAttribute]
         public string Tooltip { get; set; }
         [XmlAttribute]
-        public string Type { get; set; }
-        [XmlAttribute]
         public int Stack { get; set; }
-        [XmlAttribute]
-        public string Variant { get; set; }
+        [XmlElement("ItemField")]
+        public List<XmlObjectField> Fields { get; set; }
 
         public XmlItem() { }
 
-        public XmlItem(string id, string name, string type, int stack) {
+        public XmlItem(string id, string name, int stack) {
             ID = id;
             Name = name;
-            Type = type;
             Stack = stack;
         }
 
@@ -340,24 +348,6 @@ namespace TiTsEd.Model {
         }
     }
 
-    [Flags]
-    public enum ItemCategories {
-        Other = 1,
-        MeleeWeapon = 2,
-        RangedWeapon = 4,
-        Clothing = 8,
-        Armor = 8,
-        Shield = 16,
-        UpperUndergarment = 32,
-        LowerUndergarment = 64,
-        Accessory = 128,
-        Consumable = 256,
-        Gadget = 512,
-        All = Other | MeleeWeapon | RangedWeapon | Armor |
-            Clothing | Shield | UpperUndergarment | LowerUndergarment |
-            Accessory | Consumable | Gadget,
-    }
-
     public sealed class XmlName {
         [XmlAttribute]
         public string Name { get; set; }
@@ -367,6 +357,18 @@ namespace TiTsEd.Model {
         public override string ToString() {
             return Name;
         }
+    }
+
+    /// <summary>
+    /// Directly correlates to an entry in an Amf Object.
+    /// </summary>
+    public sealed class XmlObjectField {
+        [XmlAttribute]
+        public string Name { get; set; }
+        [XmlAttribute]
+        public string Type { get; set; }
+        [XmlAttribute]
+        public string Value { get; set; }
     }
 
     public sealed class XmlStorageClass {

--- a/TiTsEd/TiTSEd.Data.xml
+++ b/TiTsEd/TiTSEd.Data.xml
@@ -765,385 +765,430 @@
 	</Body>
 	<!-- ================================================================ -->
 	<Items>
-		<Item Type="Accessory" Stack="1" Name="ACE Cannon" ID="classes.Items.Accessories::ACECannon" />
-		<Item Type="Accessory" Stack="1" Name="AimEyepiece" ID="classes.Items.Accessories::AimEyepiece" />
-		<Item Type="Accessory" Stack="1" Name="Allure" ID="classes.Items.Accessories::Allure" />
-		<Item Type="Accessory" Stack="1" Name="FlashGogs" ID="classes.Items.Accessories::FlashGoggles" />
-		<Item Type="Accessory" Stack="1" Name="JungleLure" ID="classes.Items.Accessories::JungleLure" />
-		<Item Type="Accessory" Stack="1" Name="JungleRepel" ID="classes.Items.Accessories::JungleRepel" />
-		<Item Type="Accessory" Stack="1" Name="LeithaChrm" ID="classes.Items.Accessories::LeithaCharm" />
-		<Item Type="Accessory" Stack="1" Name="Lt.Jetpack" ID="classes.Items.Accessories::LightJetpack" />
-		<Item Type="Accessory" Stack="1" Name="L.Duster" ID="classes.Items.Accessories::LightningDuster" />
-		<Item Type="Accessory" Stack="1" Name="M.Sweeper" ID="classes.Items.Accessories::Minesweeper" />
-		<Item Type="Accessory" Stack="1" Name="MuskLure" ID="classes.Items.Accessories::MuskLure" />
-		<Item Type="Accessory" Stack="1" Name="M.Repel" ID="classes.Items.Accessories::MuskRepel" />
-		<Item Type="Accessory" Stack="1" Name="S.Duster" ID="classes.Items.Accessories::SalamanderDuster" />
-		<Item Type="Accessory" Stack="1" Name="Siegwulfe" ID="classes.Items.Accessories::SiegwulfeItem" />
-		<Item Type="Accessory" Stack="1" Name="TamWolf" ID="classes.Items.Accessories::TamWolf" />
-		<Item Type="Accessory" Stack="1" Name="TamWolf" ID="classes.Items.Accessories::TamWolfDamaged" />
-		<Item Type="Accessory" Stack="1" Name="TamWolf2.0" ID="classes.Items.Accessories::TamWolfII" />
-		<Item Type="Accessory" Stack="1" Name="Pink Leash" ID="classes.Items.Accessories::VarmintLeash" />
-		<Item Type="Accessory" Stack="1" Name="Cargobot" ID="classes.Items.Miscellaneous::Cargobot" />
-		<Item Type="Accessory" Stack="1" Name="PH Access." ID="classes.Items.Miscellaneous::PHAccess" />
-		<Item Type="Clothing" Stack="1" Name="Annos Blouse" ID="classes.Items.Apparel::AnnosBlouse" />
-		<Item Type="Clothing" Stack="1" Name="Bunny.O" ID="classes.Items.Apparel::BunnyOutfit" />
-		<Item Type="Clothing" Stack="1" Name="B.Clothes" ID="classes.Items.Apparel::BusinessClothes" />
-		<Item Type="Clothing" Stack="1" Name="Butler.C" ID="classes.Items.Apparel::ButlerCostume" />
-		<Item Type="Clothing" Stack="1" Name="Butler.O" ID="classes.Items.Apparel::ButlerOutfit" />
-		<Item Type="Clothing" Stack="1" Name="Chr.Ldr." ID="classes.Items.Apparel::CheerleaderUniform" />
-		<Item Type="Clothing" Stack="1" Name="C.Suit" ID="classes.Items.Apparel::ClassySuit" />
-		<Item Type="Clothing" Stack="1" Name="C.Clothes" ID="classes.Items.Apparel::ComfortableClothes" />
-		<Item Type="Clothing" Stack="1" Name="Cow Leotard" ID="classes.Items.Apparel::CowPrintLeotard" />
-		<Item Type="Clothing" Stack="1" Name="DressCloth" ID="classes.Items.Apparel::DressClothes" />
-		<Item Type="Clothing" Stack="1" Name="F. Doctor" ID="classes.Items.Apparel::FemaleDoctorOutfit" />
-		<Item Type="Clothing" Stack="1" Name="LabCoat" ID="classes.Items.Apparel::KhansLabCoat" />
-		<Item Type="Clothing" Stack="1" Name="LtxBdy" ID="classes.Items.Apparel::LatexBodysuit" />
-		<Item Type="Clothing" Stack="1" Name="L.Harness" ID="classes.Items.Apparel::LeatherStrapHarness" />
-		<Item Type="Clothing" Stack="1" Name="Libr.O" ID="classes.Items.Apparel::LibrarianOutfit" />
-		<Item Type="Clothing" Stack="1" Name="BlkDress" ID="classes.Items.Apparel::LittleBlackDress" />
-		<Item Type="Clothing" Stack="1" Name="MaidO." ID="classes.Items.Apparel::MaidOutfit" />
-		<Item Type="Clothing" Stack="1" Name="Maid U." ID="classes.Items.Apparel::MaidUniform" />
-		<Item Type="Clothing" Stack="1" Name="M.Doctor" ID="classes.Items.Apparel::MaleDoctorOutfit" />
-		<Item Type="Clothing" Stack="1" Name="NurseO." ID="classes.Items.Apparel::NurseOutfit" />
-		<Item Type="Clothing" Stack="1" Name="O.Swimsuit" ID="classes.Items.Apparel::OnePieceSwimsuit" />
-		<Item Type="Clothing" Stack="1" Name="PeasantDress" ID="classes.Items.Apparel::PeasantDress" />
-		<Item Type="Clothing" Stack="1" Name="S.Boy O." ID="classes.Items.Apparel::SchoolboyOutfit" />
-		<Item Type="Clothing" Stack="1" Name="S.Girl C." ID="classes.Items.Apparel::SchoolgirlCostume" />
-		<Item Type="Clothing" Stack="1" Name="S.Girl O." ID="classes.Items.Apparel::SchoolgirlOutfit" />
-		<Item Type="Clothing" Stack="1" Name="S.Dress" ID="classes.Items.Apparel::SilkDress" />
-		<Item Type="Clothing" Stack="1" Name="T.Bodysuit" ID="classes.Items.Apparel::ThermalBodysuit" />
-		<Item Type="Clothing" Stack="1" Name="TopNSkirt." ID="classes.Items.Apparel::TopNSkirt" />
-		<Item Type="Clothing" Stack="1" Name="UGC Uniform" ID="classes.Items.Apparel::UGCUniform" />
-		<Item Type="Clothing" Stack="1" Name="WaitressUniform" ID="classes.Items.Apparel::WaitressUniform" />
-		<Item Type="Clothing" Stack="1" Name="Winter G." ID="classes.Items.Apparel::WinterGear" />
-		<Item Type="Armor" Stack="1" Name="ST. Catsuit" ID="classes.Items.Apparel::AnnosCatsuit" />
-		<Item Type="Armor" Stack="1" Name="AtmaArmor" ID="classes.Items.Apparel::AtmaArmor" />
-		<Item Type="Armor" Stack="1" Name="Catsuit" ID="classes.Items.Apparel::GenericCatsuit" />
-		<Item Type="Armor" Stack="1" Name="gooverings" ID="classes.Items.Apparel::GooeyCoverings" />
-		<Item Type="Armor" Stack="1" Name="LeatherArmor" ID="classes.Items.Apparel::LeatherArmor" />
-		<Item Type="Armor" Stack="1" Name="MilitaryO." ID="classes.Items.Apparel::MilitaryUniform" />
-		<Item Type="Armor" Stack="1" Name="NaleenScale" ID="classes.Items.Apparel::NaleenArmor" />
-		<Item Type="Armor" Stack="1" Name="P.Jacket" ID="classes.Items.Apparel::ProtectiveJacket" />
-		<Item Type="Armor" Stack="1" Name="R.Bdysuit" ID="classes.Items.Apparel::ReinforcedBodysuit" />
-		<Item Type="Armor" Stack="1" Name="R.F.Armor" ID="classes.Items.Apparel::RevealingFemaleArmor" />
-		<Item Type="Armor" Stack="1" Name="R.M.Armor" ID="classes.Items.Apparel::RevealingMaleArmor" />
-		<Item Type="Armor" Stack="1" Name="Smartclothes" ID="classes.Items.Apparel::Smartclothes" />
-		<Item Type="Armor" Stack="1" Name="S.Pirate O." ID="classes.Items.Apparel::SpacePirateOutfit" />
-		<Item Type="Armor" Stack="1" Name="ST. Suit" ID="classes.Items.Apparel::SteeleTechSuit" />
-		<Item Type="Armor" Stack="1" Name="ThmJacket" ID="classes.Items.Apparel::ThermalJacket" />
-		<Item Type="Armor" Stack="1" Name="T.Zipsuit" ID="classes.Items.Apparel::TransparentZipsuit" />
-		<Item Type="Armor" Stack="1" Name="T.Armor" ID="classes.Items.Apparel::TrashArmor" />
-		<Item Type="Armor" Stack="1" Name="TST Armor" ID="classes.Items.Apparel::TSTArmor" />
-		<Item Type="Armor" Stack="1" Name="TST Armor II" ID="classes.Items.Apparel::TSTArmorMkII" />
-		<Item Type="Armor" Stack="1" Name="AZA Suit" ID="classes.Items.Armor::ArmstrongSuitBlue" />
-		<Item Type="Armor" Stack="1" Name="UVA Suit" ID="classes.Items.Armor::ArmstrongSuitViolet" />
-		<Item Type="Armor" Stack="1" Name="PWA Suit" ID="classes.Items.Armor::ArmstrongSuitWhite" />
-		<Item Type="Armor" Stack="1" Name="C.Armor" ID="classes.Items.Armor::ChitinArmor" />
-		<Item Type="Armor" Stack="1" Name="C.Plate" ID="classes.Items.Armor::ChitPlate" />
-		<Item Type="Armor" Stack="1" Name="Goo Armor" ID="classes.Items.Armor::GooArmor" />
-		<Item Type="Armor" Stack="1" Name="M.Suit" ID="classes.Items.Armor::MirroredJumpsuit" />
-		<Item Type="Armor" Stack="1" Name="N.Chain" ID="classes.Items.Armor::NyreanChain" />
-		<Item Type="Armor" Stack="1" Name="P.Plate" ID="classes.Items.Armor::PolishedPlate" />
-		<Item Type="Armor" Stack="1" Name="Void Plates" ID="classes.Items.Armor::VoidPlateArmor" />
-		<Item Type="Armor" Stack="1" Name="I.Coat" ID="classes.Items.Armor::InsulatedCoat" />
-		<Item Type="Armor" Stack="1" Name="WM Coat" ID="classes.Items.Armor::WeavemailCoat" />
-		<Item Type="Armor" Stack="1" Name="WM Dress" ID="classes.Items.Armor::WeavemailDress" />
-		<Item Type="Armor" Stack="1" Name="WM Shirt" ID="classes.Items.Armor::WeavemailShirt" />
-		<Item Type="Armor" Stack="1" Name="O.Collar" ID="classes.Items.Armor.Unique::OmnisuitCollar" />
-		<Item Type="Armor" Stack="1" Name="O.Suit" ID="classes.Items.Armor.Unique::Omnisuit" />
-		<Item Type="Armor" Stack="1" Name="S.Collar" ID="classes.Items.Armor.Unique::StrangeCollar" />
-		<Item Type="UpperUndergarment" Stack="1" Name="BikiniTop" ID="classes.Items.Apparel::FrillyBikiniTop" />
-		<Item Type="UpperUndergarment" Stack="1" Name="NetTop" ID="classes.Items.Apparel::FishnetTop" />
-		<Item Type="UpperUndergarment" Stack="1" Name="F.Bra" ID="classes.Items.Apparel::FurryBra" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Babydoll" ID="classes.Items.Apparel::Babydoll" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Bounty Bra" ID="classes.Items.Apparel::BountyBra" />
-    <Item Type="UpperUndergarment" Stack="1" Name="CrnyShirtV1" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt"/>
-		<Item Type="UpperUndergarment" Stack="1" Name="Corset" ID="classes.Items.Apparel::Corset" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Cow Bra" ID="classes.Items.Apparel::CowPrintBra" />
-		<Item Type="UpperUndergarment" Stack="1" Name="CowShirt" ID="classes.Items.Apparel::CowPrintedShirt" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Girly Bra" ID="classes.Items.Apparel::GirlyBra" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Harness" ID="classes.Items.Apparel::Harness" />
-		<Item Type="UpperUndergarment" Stack="1" Name="HoneyBra" ID="classes.Items.Apparel::HoneypotBra" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Lacy Bra" ID="classes.Items.Apparel::LacyBra" />
-		<Item Type="UpperUndergarment" Stack="1" Name="LilG.Bra" ID="classes.Items.Apparel::LittleGreenBra" />
-		<Item Type="UpperUndergarment" Stack="1" Name="LilG.Tee" ID="classes.Items.Apparel::LittleGreenShirt" />
-		<Item Type="UpperUndergarment" Stack="1" Name="LilG.Tank" ID="classes.Items.Apparel::LittleGreenTankTop" />
-		<Item Type="UpperUndergarment" Stack="1" Name="M.Shirt" ID="classes.Items.Apparel::MeshShirt" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Pasties" ID="classes.Items.Apparel::Pasties" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Bra" ID="classes.Items.Apparel::PlainBra" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Undershirt" ID="classes.Items.Apparel::PlainUndershirt" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Shibari Top" ID="classes.Items.Apparel::ShibariTop" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Sk.Bra" ID="classes.Items.Apparel::SkullPatternBra" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Sports Bra" ID="classes.Items.Apparel::SportsBra" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Underbust Corset" ID="classes.Items.Apparel::UnderbustCorset" />
-		<Item Type="UpperUndergarment" Stack="1" Name="Undershirt" ID="classes.Items.Apparel::Undershirt" />
-		<Item Type="LowerUndergarment" Stack="1" Name="BikiniBtm" ID="classes.Items.Apparel::FrillyBikiniBottom" />
-		<Item Type="LowerUndergarment" Stack="1" Name="BaggyShorts" ID="classes.Items.Apparel::BaggySwimShorts" />
-		<Item Type="LowerUndergarment" Stack="1" Name="Boxers" ID="classes.Items.Apparel::Boxers" />
-		<Item Type="LowerUndergarment" Stack="1" Name="Boyshorts" ID="classes.Items.Apparel::Boyshorts" />
-		<Item Type="LowerUndergarment" Stack="1" Name="BullStrap" ID="classes.Items.Apparel::BullsJockstrap" />
-		<Item Type="LowerUndergarment" Stack="1" Name="CockPasty" ID="classes.Items.Apparel::CockPasty" />
-		<Item Type="LowerUndergarment" Stack="1" Name="Cow Bottom" ID="classes.Items.Apparel::CowPrintBikiniBottom" />
-		<Item Type="LowerUndergarment" Stack="1" Name="Cow Panties" ID="classes.Items.Apparel::CowPrintPantiesAndGarter" />
-		<Item Type="UpperUndergarment" Stack="1" Name="CowShorts" ID="classes.Items.Apparel::CowPrintedShorts" />
-		<Item Type="LowerUndergarment" Stack="1" Name="C.String" ID="classes.Items.Apparel::CString" />
-		<Item Type="LowerUndergarment" Stack="1" Name="NetBriefs" ID="classes.Items.Apparel::FishnetBriefs" />
-		<Item Type="LowerUndergarment" Stack="1" Name="G.Panties" ID="classes.Items.Apparel::GirlyPanties" />
-		<Item Type="LowerUndergarment" Stack="1" Name="HorseBxs" ID="classes.Items.Apparel::HorseshoeBoxers" />
-		<Item Type="LowerUndergarment" Stack="1" Name="LilG.Brief" ID="classes.Items.Apparel::LittleGreenBriefs" />
-		<Item Type="LowerUndergarment" Stack="1" Name="LilG.Panty" ID="classes.Items.Apparel::LittleGreenPanties" />
-		<Item Type="LowerUndergarment" Stack="1" Name="LilG.Thong" ID="classes.Items.Apparel::LittleGreenThong" />
-		<Item Type="LowerUndergarment" Stack="1" Name="M.Thong" ID="classes.Items.Apparel::MaleThong" />
-		<Item Type="LowerUndergarment" Stack="1" Name="GuyTights" ID="classes.Items.Apparel::MaleTights" />
-		<Item Type="LowerUndergarment" Stack="1" Name="Briefs" ID="classes.Items.Apparel::PlainBriefs" />
-		<Item Type="LowerUndergarment" Stack="1" Name="Panties" ID="classes.Items.Apparel::PlainPanties" />
-		<Item Type="LowerUndergarment" Stack="1" Name="ShibariBottom" ID="classes.Items.Apparel::ShibariBottom" />
-		<Item Type="LowerUndergarment" Stack="1" Name="Stockings" ID="classes.Items.Apparel::Stockings" />
-		<Item Type="LowerUndergarment" Stack="1" Name="ThmUndies" ID="classes.Items.Apparel::ThermalUnderwear" />
-		<Item Type="LowerUndergarment" Stack="1" Name="Thong" ID="classes.Items.Apparel::Thong" />
-		<Item Type="LowerUndergarment" Stack="1" Name="Z.Pouch" ID="classes.Items.Apparel::ZipPouch" />
-		<Item Type="Consumable" Stack="5" Name="Crystal S." ID="classes.Items.Combat::CrystalShard" />
-		<Item Type="Consumable" Stack="1" Name="H.Wine" ID="classes.Items.Drinks::HoneyWine" />
-		<Item Type="Consumable" Stack="10" Name="R.Venom" ID="classes.Items.Drinks::RedMyrVenom" />
-		<Item Type="Consumable" Stack="10" Name="Anusoft" ID="classes.Items.Miscellaneous::Anusoft" />
-		<Item Type="Consumable" Stack="10" Name="AusarTreat" ID="classes.Items.Miscellaneous::AusarTreats" />
-		<Item Type="Consumable" Stack="10" Name="BBQ To-Go" ID="classes.Items.Miscellaneous::BBQToGo" />
-		<Item Type="Consumable" Stack="50" Name="Boobswell P." ID="classes.Items.Miscellaneous::BoobswellPads" />
-		<Item Type="Consumable" Stack="10" Name="Chocolac" ID="classes.Items.Miscellaneous::Chocolac" />
-		<Item Type="Consumable" Stack="10" Name="Condensol" ID="classes.Items.Miscellaneous::Condensol" />
-		<Item Type="Consumable" Stack="10" Name="Dumbfuck" ID="classes.Items.Miscellaneous::Dumbfuck" />
-		<Item Type="Consumable" Stack="10" Name="EasyFit" ID="classes.Items.Miscellaneous::EasyFit" />
-		<Item Type="Consumable" Stack="10" Name="Estrobloom" ID="classes.Items.Miscellaneous::Estrobloom" />
-		<Item Type="Consumable" Stack="10" Name="Fertite+" ID="classes.Items.Miscellaneous::FertitePlus" />
-		<Item Type="Consumable" Stack="10" Name="FocusPill" ID="classes.Items.Miscellaneous::FocusPill" />
-		<Item Type="Consumable" Stack="5" Name="F.Extract" ID="classes.Items.Miscellaneous::FungalExtract" />
-		<Item Type="Consumable" Stack="5" Name="G.M.Bots" ID="classes.Items.Miscellaneous::GrayMicrobots" />
-		<Item Type="Consumable" Stack="10" Name="Honeydew" ID="classes.Items.Miscellaneous::Honeydew" />
-		<Item Type="Consumable" Stack="10" Name="Honeypot" ID="classes.Items.Miscellaneous::Honeypot" />
-		<Item Type="Consumable" Stack="10" Name="Honeyseed" ID="classes.Items.Miscellaneous::HoneySeed" />
-		<Item Type="Consumable" Stack="10" Name="Horse-Cock" ID="classes.Items.Miscellaneous::HorseCock" />
-		<Item Type="Consumable" Stack="10" Name="HorsePill" ID="classes.Items.Miscellaneous::HorsePill" />
-		<Item Type="Consumable" Stack="10" Name="ImmBoost" ID="classes.Items.Miscellaneous::ImmunoBooster" />
-		<Item Type="Consumable" Stack="10" Name="K.Crunch" ID="classes.Items.Miscellaneous::Kalocrunch" />
-		<Item Type="Consumable" Stack="10" Name="KnotAProb" ID="classes.Items.Miscellaneous::KnotAProblem" />
-		<Item Type="Consumable" Stack="10" Name="Lactaid" ID="classes.Items.Miscellaneous::Lactaid" />
-		<Item Type="Consumable" Stack="10" Name="LactaidMT" ID="classes.Items.Miscellaneous::LactaidMilkTank" />
-		<Item Type="Consumable" Stack="10" Name="LactaidO" ID="classes.Items.Miscellaneous::LactaidOverdrive" />
-		<Item Type="Consumable" Stack="12" Name="LargeEgg" ID="classes.Items.Miscellaneous::LargeEgg" />
-		<Item Type="Consumable" Stack="10" Name="M.Mango" ID="classes.Items.Miscellaneous::MhengaMango" />
-		<Item Type="Consumable" Stack="10" Name="M.Tight" ID="classes.Items.Miscellaneous::MightyTight" />
-		<Item Type="Consumable" Stack="50" Name="Milk Gushers" ID="classes.Items.Miscellaneous::MilkCaramelGushers" />
-		<Item Type="Consumable" Stack="50" Name="Milk. Aid" ID="classes.Items.Miscellaneous::MilkmaidsAid" />
-		<Item Type="Consumable" Stack="10" Name="MyrNectr" ID="classes.Items.Miscellaneous::MyrNectar" />
-		<Item Type="Consumable" Stack="10" Name="NaleenNip" ID="classes.Items.Miscellaneous::NaleenNip" />
-		<Item Type="Consumable" Stack="10" Name="Nuki C." ID="classes.Items.Miscellaneous::NukiCookies" />
-		<Item Type="Consumable" Stack="10" Name="OS StimBoost" ID="classes.Items.Miscellaneous::OSStimBoost" />
-		<Item Type="Consumable" Stack="10" Name="Ovilium" ID="classes.Items.Miscellaneous::Ovilium" />
-		<Item Type="Consumable" Stack="10" Name="Pandaneen" ID="classes.Items.Miscellaneous::Pandaneen" />
-		<Item Type="Consumable" Stack="10" Name="Panda Pro" ID="classes.Items.Miscellaneous::PandaPro" />
-		<Item Type="Consumable" Stack="10" Name="Priapin" ID="classes.Items.Miscellaneous::Priapin" />
-		<Item Type="Consumable" Stack="20" Name="Goblin P." ID="classes.Items.Miscellaneous::ProphylacticGoblin" />
-		<Item Type="Consumable" Stack="20" Name="LapinaraP" ID="classes.Items.Miscellaneous::ProphylacticLapinara" />
-		<Item Type="Consumable" Stack="20" Name="Rask P." ID="classes.Items.Miscellaneous::ProphylacticRaskvel" />
-		<Item Type="Consumable" Stack="20" Name="Sydian P." ID="classes.Items.Miscellaneous::ProphylacticSydian" />
-		<Item Type="Consumable" Stack="10" Name="Pussybloom" ID="classes.Items.Miscellaneous::Pussybloom" />
-		<Item Type="Consumable" Stack="10" Name="Pussyblossom" ID="classes.Items.Miscellaneous::Pussyblossom" />
-		<Item Type="Consumable" Stack="20" Name="Rainbotox" ID="classes.Items.Miscellaneous::Rainbotox" />
-		<Item Type="Consumable" Stack="5" Name="S.Booster" ID="classes.Items.Miscellaneous::ShieldBooster" />
-		<Item Type="Consumable" Stack="10" Name="SkySap" ID="classes.Items.Miscellaneous::SkySap" />
-		<Item Type="Consumable" Stack="12" Name="SmallEgg" ID="classes.Items.Miscellaneous::SmallEgg" />
-		<Item Type="Consumable" Stack="10" Name="Sterilex" ID="classes.Items.Miscellaneous::Sterilex" />
-		<Item Type="Consumable" Stack="1" Name="S.Egg" ID="classes.Items.Miscellaneous::StrangeEgg" />
-		<Item Type="Consumable" Stack="10" Name="SynthSap" ID="classes.Items.Miscellaneous::SynthSap" />
-		<Item Type="Consumable" Stack="10" Name="Human T." ID="classes.Items.Miscellaneous::TerranTreats" />
-		<Item Type="Consumable" Stack="10" Name="HP Boost" ID="classes.Items.Miscellaneous::TestHPBooster" />
-		<Item Type="Consumable" Stack="20" Name="Throbb" ID="classes.Items.Miscellaneous::Throbb" />
-		<Item Type="Consumable" Stack="10" Name="Tittyblossom" ID="classes.Items.Miscellaneous::Tittyblossom" />
-		<Item Type="Consumable" Stack="10" Name="Treatment" ID="classes.Items.Miscellaneous::Treatment" />
-		<Item Type="Consumable" Stack="10" Name="UthraSap" ID="classes.Items.Miscellaneous::UthraSap" />
-		<Item Type="Consumable" Stack="10" Name="VenusPod" ID="classes.Items.Miscellaneous::VenusPod" />
-		<Item Type="Consumable" Stack="10" Name="YT.Lube" ID="classes.Items.Miscellaneous::YTRLube" />
-		<Item Type="Consumable" Stack="10" Name="ZilHoney" ID="classes.Items.Miscellaneous::ZilHoney" />
-		<Item Type="Consumable" Stack="10" Name="ZilRation" ID="classes.Items.Miscellaneous::ZilRation" />
-		<Item Type="Consumable" Stack="10" Name="P.Saliva" ID="classes.Items.Recovery::PexigaSaliva" />
-		<Item Type="Consumable" Stack="5" Name="S.Boost M2" ID="classes.Items.Recovery::ShieldBoosterMkII" />
-		<Item Type="Consumable" Stack="1" Name="H.Bubble" ID="classes.Items.Toys.Bubbles::HugeCumBubble" />
-		<Item Type="Consumable" Stack="5" Name="L.Bubble" ID="classes.Items.Toys.Bubbles::LargeCumBubble" />
-		<Item Type="Consumable" Stack="10" Name="M.Bubble" ID="classes.Items.Toys.Bubbles::MediumCumBubble" />
-		<Item Type="Consumable" Stack="20" Name="S.Bubble" ID="classes.Items.Toys.Bubbles::SmallCumBubble" />
-		<Item Type="Consumable" Stack="5" Name="BGreenPot" ID="classes.Items.Transformatives::BigGreenPotion" />
-		<Item Type="Consumable" Stack="10" Name="Bovinium" ID="classes.Items.Transformatives::Bovinium" />
-		<Item Type="Consumable" Stack="10" Name="BumpyRd." ID="classes.Items.Transformatives::BumpyRoad" />
-		<Item Type="Consumable" Stack="10" Name="Catnip" ID="classes.Items.Transformatives::Catnip" />
-		<Item Type="Consumable" Stack="10" Name="Cerespirin" ID="classes.Items.Transformatives::Cerespirin" />
-		<Item Type="Consumable" Stack="10" Name="Circumser" ID="classes.Items.Transformatives::Circumscriber" />
-		<Item Type="Consumable" Stack="10" Name="ClearYu" ID="classes.Items.Transformatives::ClearYu" />
-		<Item Type="Consumable" Stack="10" Name="Clippex" ID="classes.Items.Transformatives::Clippex" />
-		<Item Type="Consumable" Stack="10" Name="DendroGro" ID="classes.Items.Transformatives::DendroGro" />
-		<Item Type="Consumable" Stack="10" Name="Dong D." ID="classes.Items.Transformatives::DongDesigner" />
-		<Item Type="Consumable" Stack="10" Name="Dove Balm" ID="classes.Items.Transformatives::DoveBalm" />
-		<Item Type="Consumable" Stack="10" Name="DracoG." ID="classes.Items.Transformatives::DracoGuard" />
-		<Item Type="Consumable" Stack="10" Name="Equilicum" ID="classes.Items.Transformatives::Equilicum" />
-		<Item Type="Consumable" Stack="24" Name="Lg.BluEgg" ID="classes.Items.Transformatives::EggBlueLarge" />
-		<Item Type="Consumable" Stack="24" Name="Sm.BluEgg" ID="classes.Items.Transformatives::EggBlueSmall" />
-		<Item Type="Consumable" Stack="24" Name="Lg.PinkEgg" ID="classes.Items.Transformatives::EggPinkLarge" />
-		<Item Type="Consumable" Stack="24" Name="Sm.PinkEgg" ID="classes.Items.Transformatives::EggPinkSmall" />
-		<Item Type="Consumable" Stack="24" Name="Lg.WhtEgg" ID="classes.Items.Transformatives::EggWhiteLarge" />
-		<Item Type="Consumable" Stack="24" Name="Sm.WhtEgg" ID="classes.Items.Transformatives::EggWhiteSmall" />
-		<Item Type="Consumable" Stack="1" Name="Foxfire" ID="classes.Items.Transformatives::Foxfire" />
-		<Item Type="Consumable" Stack="1" Name="Frostfire" ID="classes.Items.Transformatives::Frostfire" />
-		<Item Type="Consumable" Stack="10" Name="GaloMax" ID="classes.Items.Transformatives::GaloMax" />
-		<Item Type="Consumable" Stack="10" Name="Goblinola" ID="classes.Items.Transformatives::Goblinola" />
-		<Item Type="Consumable" Stack="10" Name="Gold Pill" ID="classes.Items.Transformatives::GoldPill" />
-		<Item Type="Consumable" Stack="10" Name="BlueGB" ID="classes.Items.Transformatives::GooBallBlue" />
-		<Item Type="Consumable" Stack="10" Name="GreenGB" ID="classes.Items.Transformatives::GooBallGreen" />
-		<Item Type="Consumable" Stack="10" Name="Orng.GB" ID="classes.Items.Transformatives::GooBallOrange" />
-		<Item Type="Consumable" Stack="10" Name="Pink GB" ID="classes.Items.Transformatives::GooBallPink" />
-		<Item Type="Consumable" Stack="10" Name="Purp.GB" ID="classes.Items.Transformatives::GooBallPurple" />
-		<Item Type="Consumable" Stack="10" Name="Red GB" ID="classes.Items.Transformatives::GooBallRed" />
-		<Item Type="Consumable" Stack="10" Name="Yellow GB" ID="classes.Items.Transformatives::GooBallYellow" />
-		<Item Type="Consumable" Stack="10" Name="Gush" ID="classes.Items.Transformatives::Gush" />
-		<Item Type="Consumable" Stack="10" Name="H-izer" ID="classes.Items.Transformatives::Honeyizer" />
-		<Item Type="Consumable" Stack="10" Name="Hornitol" ID="classes.Items.Transformatives::Hornitol" />
-		<Item Type="Consumable" Stack="10" Name="HuskarTreat" ID="classes.Items.Transformatives::HuskarTreats" />
-		<Item Type="Consumable" Stack="10" Name="J.Trunk" ID="classes.Items.Transformatives::JunkTrunk" />
-		<Item Type="Consumable" Stack="10" Name="Kero.Ven." ID="classes.Items.Transformatives::KerokorasVenom" />
-		<Item Type="Consumable" Stack="10" Name="Lucifier" ID="classes.Items.Transformatives::Lucifier" />
-		<Item Type="Consumable" Stack="10" Name="ManUp" ID="classes.Items.Transformatives::ManUp" />
-		<Item Type="Consumable" Stack="10" Name="MinoCharge" ID="classes.Items.Transformatives::MinoCharge" />
-		<Item Type="Consumable" Stack="10" Name="Nepeta" ID="classes.Items.Transformatives::Nepeta" />
-		<Item Type="Consumable" Stack="10" Name="N.Butter" ID="classes.Items.Transformatives::NukiNutbutter" />
-		<Item Type="Consumable" Stack="10" Name="Nutnog" ID="classes.Items.Transformatives::Nutnog" />
-		<Item Type="Consumable" Stack="10" Name="N.Candy" ID="classes.Items.Transformatives::NyreanCandy" />
-		<Item Type="Consumable" Stack="10" Name="Orange P." ID="classes.Items.Transformatives::OrangePill" />
-		<Item Type="Consumable" Stack="10" Name="OvirAce" ID="classes.Items.Transformatives::OvirAce" />
-		<Item Type="Consumable" Stack="5" Name="Ovir+" ID="classes.Items.Transformatives::OvirPositive" />
-		<Item Type="Consumable" Stack="10" Name="Peckermint" ID="classes.Items.Transformatives::Peckermint" />
-		<Item Type="Consumable" Stack="10" Name="RainbowG." ID="classes.Items.Transformatives::RainbowGaze" />
-		<Item Type="Consumable" Stack="10" Name="Red Pill" ID="classes.Items.Transformatives::RedPill" />
-		<Item Type="Consumable" Stack="10" Name="R.Made" ID="classes.Items.Transformatives::RubberMade" />
-		<Item Type="Consumable" Stack="10" Name="Ruskvel" ID="classes.Items.Transformatives::Ruskvel" />
-		<Item Type="Consumable" Stack="10" Name="JawBreakr" ID="classes.Items.Transformatives::SaltyJawBreaker" />
-		<Item Type="Consumable" Stack="10" Name="Semens F." ID="classes.Items.Transformatives::SemensFriend" />
-		<Item Type="Consumable" Stack="12" Name="Suma" ID="classes.Items.Transformatives::SumaCream" />
-		<Item Type="Consumable" Stack="12" Name="Suma Blk." ID="classes.Items.Transformatives::SumaCreamBlack" />
-		<Item Type="Consumable" Stack="12" Name="Suma" ID="classes.Items.Transformatives::SumaCreamWhite" />
-		<Item Type="Consumable" Stack="10" Name="SwtSweat" ID="classes.Items.Transformatives::SweetSweat" />
-		<Item Type="Consumable" Stack="10" Name="Sylvanol" ID="classes.Items.Transformatives::Sylvanol" />
-		<Item Type="Consumable" Stack="10" Name="T.Neck" ID="classes.Items.Transformatives::Turtleneck" />
-		<Item Type="Consumable" Stack="10" Name="Virection" ID="classes.Items.Transformatives::Virection" />
-		<Item Type="Gadget" Stack="10" Name="A.Cock" ID="classes.Items.Miscellaneous::ACock" />
-		<Item Type="Gadget" Stack="10" Name="A.D.Cock" ID="classes.Items.Miscellaneous::ADCock" />
-		<Item Type="Gadget" Stack="10" Name="A.H.Cock" ID="classes.Items.Miscellaneous::AHCock" />
-		<Item Type="Gadget" Stack="1" Name="ClimbKit" ID="classes.Items.Miscellaneous::ClimbingKit" />
-		<Item Type="Gadget" Stack="10" Name="Dong D." ID="classes.Items.Transformatives::DongDesigner" />
-		<Item Type="Gadget" Stack="10" Name="Fish.Rod" ID="classes.Items.Miscellaneous::FishingRod" />
-		<Item Type="Gadget" Stack="10" Name="Horse-Cock" ID="classes.Items.Miscellaneous::HorseCock" />
-		<Item Type="Gadget" Stack="1" Name="Hoverboard" ID="classes.Items.Miscellaneous::Hoverboard" />
-		<Item Type="Gadget" Stack="1" Name="M.Milker" ID="classes.Items.Miscellaneous::MagicMilker" />
-		<Item Type="Gadget" Stack="10" Name="MilkBag" ID="classes.Items.Miscellaneous::MilkBag" />
-		<Item Type="Gadget" Stack="10" Name="Silicone" ID="classes.Items.Miscellaneous::Silicone" />
-		<Item Type="Gadget" Stack="10" Name="JokeBook" ID="classes.Items.Miscellaneous::TarkusJokeBook" />
-		<Item Type="Gadget" Stack="10" Name="T.Pack" ID="classes.Items.Miscellaneous::ThermalPack" />
-		<Item Type="Gadget" Stack="1" Name="Varmint" ID="classes.Items.Miscellaneous::VarmintItem" />
-		<Item Type="Gadget" Stack="1" Name="B.Buddy" ID="classes.Items.Toys::BubbleBuddy" />
-		<Item Type="Gadget" Stack="1" Name="EggTrnr" ID="classes.Items.Toys::EggTrainer" />
-		<Item Type="Gadget" Stack="1" Name="G.Cuffs" ID="classes.Items.Toys::GravCuffs" />
-		<Item Type="Gadget" Stack="1" Name="H.Hole" ID="classes.Items.Toys::HoverHole" />
-		<Item Type="Gadget" Stack="1" Name="N.B.Hole" ID="classes.Items.Toys::NivasBionaHole" />
-		<Item Type="Gadget" Stack="1" Name="T.B.Hole" ID="classes.Items.Toys::TamaniBionaHole" />
-		<Item Type="Gadget" Stack="1" Name="SukMastr" ID="classes.Items.Toys::SukMastr" />
-		<Item Type="MeleeWeapon" Stack="1" Name="BioWhip" ID="classes.Items.Melee::BioWhip" />
-		<Item Type="MeleeWeapon" Stack="1" Name="C.Saber" ID="classes.Items.Melee::CavalrySaber" />
-		<Item Type="MeleeWeapon" Stack="1" Name="Cutlass" ID="classes.Items.Melee::Cutlass" />
-		<Item Type="MeleeWeapon" Stack="1" Name="E's Hmmr" ID="classes.Items.Melee::EmmysJolthammer" LongName="Emmy's Jolthammer" />
-		<Item Type="MeleeWeapon" Stack="1" Name="E'sSaber" ID="classes.Items.Melee::EmmysLavaSaber" LongName="Emmy's Lava Saber" />
-		<Item Type="MeleeWeapon" Stack="1" Name="E's Blade" ID="classes.Items.Melee::EmmysVampBlade" LongName="Emmy's Vamp Blade" />
-		<Item Type="MeleeWeapon" Stack="1" Name="J.Hmmr." ID="classes.Items.Melee::Jolthammer" />
-		<Item Type="MeleeWeapon" Stack="1" Name="Knife" ID="classes.Items.Melee::Knife" />
-		<Item Type="MeleeWeapon" Stack="1" Name="L.Saber" ID="classes.Items.Melee::LavaSaber" />
-		<Item Type="MeleeWeapon" Stack="1" Name="Machete" ID="classes.Items.Melee::Machette" />
-		<Item Type="MeleeWeapon" Stack="1" Name="M.Pick" ID="classes.Items.Melee::MilitaryPick" />
-		<Item Type="MeleeWeapon" Stack="1" Name="M.Saber" ID="classes.Items.Melee::MonofilamentSaber" />
-		<Item Type="MeleeWeapon" Stack="1" Name="N.Spear" ID="classes.Items.Melee::NyreanSpear" />
-		<Item Type="MeleeWeapon" Stack="1" Name="P.Talons" ID="classes.Items.Melee::PredatorTalons" />
-		<Item Type="MeleeWeapon" Stack="1" Name="Wrench" ID="classes.Items.Melee::RaskvelWrench" />
-		<Item Type="MeleeWeapon" Stack="1" Name="Rock" ID="classes.Items.Melee::Rock" />
-		<Item Type="MeleeWeapon" Stack="1" Name="R.Hammer" ID="classes.Items.Melee::RocketHammer" />
-		<Item Type="MeleeWeapon" Stack="1" Name="ShockBlade" ID="classes.Items.Melee::ShockBlade" />
-		<Item Type="MeleeWeapon" Stack="1" Name="Shortsword" ID="classes.Items.Melee::Shortsword" />
-		<Item Type="MeleeWeapon" Stack="1" Name="SurvAxe" ID="classes.Items.Melee::SurvivalAxe" />
-		<Item Type="MeleeWeapon" Stack="1" Name="T.Spear" ID="classes.Items.Melee::TaivrasSpear" />
-		<Item Type="MeleeWeapon" Stack="1" Name="T.Scalpel" ID="classes.Items.Melee::ThermalScalpel" />
-		<Item Type="MeleeWeapon" Stack="1" Name="V.Blade" ID="classes.Items.Melee::VampBlade" />
-		<Item Type="MeleeWeapon" Stack="1" Name="Vanae Spear" ID="classes.Items.Melee::VanaeSpear" />
-		<Item Type="MeleeWeapon" Stack="1" Name="Warhammer" ID="classes.Items.Melee::Warhammer" />
-		<Item Type="MeleeWeapon" Stack="1" Name="Whip" ID="classes.Items.Melee::Whip" />
-		<Item Type="MeleeWeapon" Stack="1" Name="Y.Strap" ID="classes.Items.Melee::YappiStrap" />
-		<Item Type="RangedWeapon" Stack="1" Name="Aegis MG" ID="classes.Items.Guns::AegisLightMG" />
-		<Item Type="RangedWeapon" Stack="1" Name="ArcCast." ID="classes.Items.Guns::ArcCaster" />
-		<Item Type="RangedWeapon" Stack="1" Name="B.Light" ID="classes.Items.Guns::BlackLight" />
-		<Item Type="RangedWeapon" Stack="1" Name="B.Rifle" ID="classes.Items.Guns::BoltActionRifle" />
-		<Item Type="RangedWeapon" Stack="1" Name="Custom LP-17" ID="classes.Items.Guns::CustomLP17" LongName="Custom LP-17 Laser Pistol" />
-		<Item Type="RangedWeapon" Stack="1" Name="E.Handgun" ID="classes.Items.Guns::EagleHandgun" />
-		<Item Type="RangedWeapon" Stack="1" Name="Electrogun" ID="classes.Items.Guns::Electrogun" />
-		<Item Type="RangedWeapon" Stack="1" Name="E's Pistol" ID="classes.Items.Guns::EmmysSalamanderPistol" LongName="Emmy's Salamander Pistol" />
-		<Item Type="RangedWeapon" Stack="1" Name="E's Rifle" ID="classes.Items.Guns::EmmysSalamanderRifle" LongName="Emmy's Salamander Rifle" />
-		<Item Type="RangedWeapon" Stack="1" Name="E's S.R." ID="classes.Items.Guns::EmmysSalamanderRifle2" LongName="Emmy's Tweaked Salamander Rifle" />
-		<Item Type="RangedWeapon" Stack="1" Name="FlareGun" ID="classes.Items.Guns::FlareGun" />
-		<Item Type="RangedWeapon" Stack="1" Name="Goovolver" ID="classes.Items.Guns::Goovolver" />
-		<Item Type="RangedWeapon" Stack="1" Name="Hammer C." ID="classes.Items.Guns::HammerCarbine" />
-		<Item Type="RangedWeapon" Stack="1" Name="Hammer Pstl." ID="classes.Items.Guns::HammerPistol" />
-		<Item Type="RangedWeapon" Stack="1" Name="Hammer Pstl." ID="classes.Items.Guns::HammerPistolScavenged" />
-		<Item Type="RangedWeapon" Stack="1" Name="Holdout H.P." ID="classes.Items.Guns::HoldoutHP" />
-		<Item Type="RangedWeapon" Stack="1" Name="Hld.Pistol" ID="classes.Items.Guns::HoldOutPistol" />
-		<Item Type="RangedWeapon" Stack="1" Name="H.Rifle" ID="classes.Items.Guns::HuntingRifle" />
-		<Item Type="RangedWeapon" Stack="1" Name="Khans AC." ID="classes.Items.Guns::KhansArcCaster" />
-		<Item Type="RangedWeapon" Stack="1" Name="Laser C." ID="classes.Items.Guns::LaserCarbine" />
-		<Item Type="RangedWeapon" Stack="1" Name="LaserPistol" ID="classes.Items.Guns::LaserPistol" />
-		<Item Type="RangedWeapon" Stack="1" Name="Mag.Pistol" ID="classes.Items.Guns::MagnumPistol" />
-		<Item Type="RangedWeapon" Stack="1" Name="Myr Bow" ID="classes.Items.Guns::MyrBow" />
-		<Item Type="RangedWeapon" Stack="1" Name="M.Rifle" ID="classes.Items.Guns::MyrRifle" />
-		<Item Type="RangedWeapon" Stack="1" Name="Nova Pstl." ID="classes.Items.Guns::NovaPistol" />
-		<Item Type="RangedWeapon" Stack="1" Name="Nova Rifle" ID="classes.Items.Guns::NovaRifle" />
-		<Item Type="RangedWeapon" Stack="1" Name="PlasmaBore" ID="classes.Items.Guns::PlasmaBore" />
-		<Item Type="RangedWeapon" Stack="1" Name="Plasma P." ID="classes.Items.Guns::PlasmaPistol" />
-		<Item Type="RangedWeapon" Stack="1" Name="P.Bow" ID="classes.Items.Guns::PrimitiveBow" />
-		<Item Type="RangedWeapon" Stack="1" Name="Royal Bow" ID="classes.Items.Guns::QueensBow" />
-		<Item Type="RangedWeapon" Stack="1" Name="Revolvr" ID="classes.Items.Guns::RudimentaryRevolver" />
-		<Item Type="RangedWeapon" Stack="1" Name="SalPistl" ID="classes.Items.Guns::SalamanderPistol" />
-		<Item Type="RangedWeapon" Stack="1" Name="SalRifle" ID="classes.Items.Guns::SalamanderRifle" />
-		<Item Type="RangedWeapon" Stack="1" Name="S.Pistol" ID="classes.Items.Guns::ScopedPistol" />
-		<Item Type="RangedWeapon" Stack="1" Name="secureMP" ID="classes.Items.Guns::SecureMP" />
-		<Item Type="RangedWeapon" Stack="1" Name="SlutRay" ID="classes.Items.Guns::SlutRay" />
-		<Item Type="RangedWeapon" Stack="1" Name="A.SlutRay" ID="classes.Items.Guns::SlutRayAdvanced" />
-		<Item Type="RangedWeapon" Stack="1" Name="SunFire" ID="classes.Items.Guns::SunFire" />
-		<Item Type="RangedWeapon" Stack="1" Name="Tach. Beam" ID="classes.Items.Guns::TachyonBeamLaser" />
-		<Item Type="RangedWeapon" Stack="1" Name="Tanis's Bow" ID="classes.Items.Guns::TanisBow" />
-		<Item Type="RangedWeapon" Stack="1" Name="TheShocker" ID="classes.Items.Guns::TheShocker" />
-		<Item Type="RangedWeapon" Stack="1" Name="Shotgn" ID="classes.Items.Guns::TrenchShotgun" />
-		<Item Type="RangedWeapon" Stack="1" Name="ZK Rifle" ID="classes.Items.Guns::ZKRifle" />
-		<Item Type="Shield" Stack="1" Name="AW Belt" ID="classes.Items.Protection::ArcticWarfareBelt" />
-		<Item Type="Shield" Stack="1" Name="BasicShld" ID="classes.Items.Protection::BasicShield" />
-		<Item Type="Shield" Stack="1" Name="DBG Shield" ID="classes.Items.Protection::DBGShield" />
-		<Item Type="Shield" Stack="1" Name="Decent S." ID="classes.Items.Protection::DecentShield" />
-		<Item Type="Shield" Stack="1" Name="HeatBelt" ID="classes.Items.Protection::HeatBelt" />
-		<Item Type="Shield" Stack="1" Name="I.Shield" ID="classes.Items.Protection::ImprovisedShield" />
-		<Item Type="Shield" Stack="1" Name="E.Shield" ID="classes.Items.Protection::JoyCoEliteShield" />
-		<Item Type="Shield" Stack="1" Name="P.Shield" ID="classes.Items.Protection::JoyCoPremiumShield" />
-		<Item Type="Shield" Stack="1" Name="O.Aegis" ID="classes.Items.Protection::OzoneAegis" />
-		<Item Type="Shield" Stack="1" Name="Mark IIS" ID="classes.Items.Protection::ReaperArmamentsMarkIIShield" />
-		<Item Type="Shield" Stack="1" Name="Mark I.S." ID="classes.Items.Protection::ReaperArmamentsMarkIShield" />
-		<Item Type="Shield" Stack="1" Name="S.Shield" ID="classes.Items.Protection::SalamanderShield" />
-		<Item Type="Other" Stack="10" Name="EMP Gren." ID="classes.Items.Miscellaneous::EMPGrenade" />
-		<Item Type="Other" Stack="10" Name="Flashbang" ID="classes.Items.Miscellaneous::FlashGrenade" />
-		<Item Type="Other" Stack="10" Name="T.Gren" ID="classes.Items.Miscellaneous::TestGrenade" />
-		<Item Type="Other" Stack="2" Name="GemSack" ID="classes.Items.Miscellaneous::GemSatchel" />
-		<Item Type="Other" Stack="20" Name="Kirkite" ID="classes.Items.Miscellaneous::Kirkite" />
-		<Item Type="Other" Stack="20" Name="Picardine" ID="classes.Items.Miscellaneous::Picardine" />
-		<Item Type="Other" Stack="20" Name="Satyrite" ID="classes.Items.Miscellaneous::Satyrite" />
-		<Item Type="Other" Stack="1" Name="V.Bloom" ID="classes.Items.Miscellaneous::VenusBloom" />
-		<Item Type="Other" Stack="5" Name="W.Drone" ID="classes.Items.Miscellaneous::WeatherDrone" />
+		<ItemType Name="Accessory">
+			<Item Stack="1" Name="ACE Cannon" ID="classes.Items.Accessories::ACECannon" />
+			<Item Stack="1" Name="AimEyepiece" ID="classes.Items.Accessories::AimEyepiece" />
+			<Item Stack="1" Name="Allure" ID="classes.Items.Accessories::Allure" />
+			<Item Stack="1" Name="FlashGogs" ID="classes.Items.Accessories::FlashGoggles" />
+			<Item Stack="1" Name="JungleLure" ID="classes.Items.Accessories::JungleLure" />
+			<Item Stack="1" Name="JungleRepel" ID="classes.Items.Accessories::JungleRepel" />
+			<Item Stack="1" Name="LeithaChrm" ID="classes.Items.Accessories::LeithaCharm" />
+			<Item Stack="1" Name="Lt.Jetpack" ID="classes.Items.Accessories::LightJetpack" />
+			<Item Stack="1" Name="L.Duster" ID="classes.Items.Accessories::LightningDuster" />
+			<Item Stack="1" Name="M.Sweeper" ID="classes.Items.Accessories::Minesweeper" />
+			<Item Stack="1" Name="MuskLure" ID="classes.Items.Accessories::MuskLure" />
+			<Item Stack="1" Name="M.Repel" ID="classes.Items.Accessories::MuskRepel" />
+			<Item Stack="1" Name="S.Duster" ID="classes.Items.Accessories::SalamanderDuster" />
+			<Item Stack="1" Name="Siegwulfe" ID="classes.Items.Accessories::SiegwulfeItem" />
+			<Item Stack="1" Name="TamWolf" ID="classes.Items.Accessories::TamWolf" />
+			<Item Stack="1" Name="TamWolf" ID="classes.Items.Accessories::TamWolfDamaged" />
+			<Item Stack="1" Name="TamWolf2.0" ID="classes.Items.Accessories::TamWolfII" />
+			<Item Stack="1" Name="Pink Leash" ID="classes.Items.Accessories::VarmintLeash" />
+			<Item Stack="1" Name="Cargobot" ID="classes.Items.Miscellaneous::Cargobot" />
+			<Item Stack="1" Name="PH Access." ID="classes.Items.Miscellaneous::PHAccess" />
+		</ItemType>
+		<ItemType Name="Clothing">
+			<Item Stack="1" Name="Annos Blouse" ID="classes.Items.Apparel::AnnosBlouse" />
+			<Item Stack="1" Name="Bunny.O" ID="classes.Items.Apparel::BunnyOutfit" />
+			<Item Stack="1" Name="B.Clothes" ID="classes.Items.Apparel::BusinessClothes" />
+			<Item Stack="1" Name="Butler.C" ID="classes.Items.Apparel::ButlerCostume" />
+			<Item Stack="1" Name="Butler.O" ID="classes.Items.Apparel::ButlerOutfit" />
+			<Item Stack="1" Name="Chr.Ldr." ID="classes.Items.Apparel::CheerleaderUniform" />
+			<Item Stack="1" Name="C.Suit" ID="classes.Items.Apparel::ClassySuit" />
+			<Item Stack="1" Name="C.Clothes" ID="classes.Items.Apparel::ComfortableClothes" />
+			<Item Stack="1" Name="Cow Leotard" ID="classes.Items.Apparel::CowPrintLeotard" />
+			<Item Stack="1" Name="DressCloth" ID="classes.Items.Apparel::DressClothes" />
+			<Item Stack="1" Name="F. Doctor" ID="classes.Items.Apparel::FemaleDoctorOutfit" />
+			<Item Stack="1" Name="LabCoat" ID="classes.Items.Apparel::KhansLabCoat" />
+			<Item Stack="1" Name="LtxBdy" ID="classes.Items.Apparel::LatexBodysuit" />
+			<Item Stack="1" Name="L.Harness" ID="classes.Items.Apparel::LeatherStrapHarness" />
+			<Item Stack="1" Name="Libr.O" ID="classes.Items.Apparel::LibrarianOutfit" />
+			<Item Stack="1" Name="BlkDress" ID="classes.Items.Apparel::LittleBlackDress" />
+			<Item Stack="1" Name="MaidO." ID="classes.Items.Apparel::MaidOutfit" />
+			<Item Stack="1" Name="Maid U." ID="classes.Items.Apparel::MaidUniform" />
+			<Item Stack="1" Name="M.Doctor" ID="classes.Items.Apparel::MaleDoctorOutfit" />
+			<Item Stack="1" Name="NurseO." ID="classes.Items.Apparel::NurseOutfit" />
+			<Item Stack="1" Name="O.Swimsuit" ID="classes.Items.Apparel::OnePieceSwimsuit" />
+			<Item Stack="1" Name="PeasantDress" ID="classes.Items.Apparel::PeasantDress" />
+			<Item Stack="1" Name="S.Boy O." ID="classes.Items.Apparel::SchoolboyOutfit" />
+			<Item Stack="1" Name="S.Girl C." ID="classes.Items.Apparel::SchoolgirlCostume" />
+			<Item Stack="1" Name="S.Girl O." ID="classes.Items.Apparel::SchoolgirlOutfit" />
+			<Item Stack="1" Name="S.Dress" ID="classes.Items.Apparel::SilkDress" />
+			<Item Stack="1" Name="T.Bodysuit" ID="classes.Items.Apparel::ThermalBodysuit" />
+			<Item Stack="1" Name="TopNSkirt." ID="classes.Items.Apparel::TopNSkirt" />
+			<Item Stack="1" Name="UGC Uniform" ID="classes.Items.Apparel::UGCUniform" />
+			<Item Stack="1" Name="WaitressUniform" ID="classes.Items.Apparel::WaitressUniform" />
+			<Item Stack="1" Name="Winter G." ID="classes.Items.Apparel::WinterGear" />
+		</ItemType>
+		<ItemType Name="Armor">
+			<Item Stack="1" Name="ST. Catsuit" ID="classes.Items.Apparel::AnnosCatsuit" />
+			<Item Stack="1" Name="AtmaArmor" ID="classes.Items.Apparel::AtmaArmor" />
+			<Item Stack="1" Name="Catsuit" ID="classes.Items.Apparel::GenericCatsuit" />
+			<Item Stack="1" Name="gooverings" ID="classes.Items.Apparel::GooeyCoverings" />
+			<Item Stack="1" Name="LeatherArmor" ID="classes.Items.Apparel::LeatherArmor" />
+			<Item Stack="1" Name="MilitaryO." ID="classes.Items.Apparel::MilitaryUniform" />
+			<Item Stack="1" Name="NaleenScale" ID="classes.Items.Apparel::NaleenArmor" />
+			<Item Stack="1" Name="P.Jacket" ID="classes.Items.Apparel::ProtectiveJacket" />
+			<Item Stack="1" Name="R.Bdysuit" ID="classes.Items.Apparel::ReinforcedBodysuit" />
+			<Item Stack="1" Name="R.F.Armor" ID="classes.Items.Apparel::RevealingFemaleArmor" />
+			<Item Stack="1" Name="R.M.Armor" ID="classes.Items.Apparel::RevealingMaleArmor" />
+			<Item Stack="1" Name="Smartclothes" ID="classes.Items.Apparel::Smartclothes" />
+			<Item Stack="1" Name="S.Pirate O." ID="classes.Items.Apparel::SpacePirateOutfit" />
+			<Item Stack="1" Name="ST. Suit" ID="classes.Items.Apparel::SteeleTechSuit" />
+			<Item Stack="1" Name="ThmJacket" ID="classes.Items.Apparel::ThermalJacket" />
+			<Item Stack="1" Name="T.Zipsuit" ID="classes.Items.Apparel::TransparentZipsuit" />
+			<Item Stack="1" Name="T.Armor" ID="classes.Items.Apparel::TrashArmor" />
+			<Item Stack="1" Name="TST Armor" ID="classes.Items.Apparel::TSTArmor" />
+			<Item Stack="1" Name="TST Armor II" ID="classes.Items.Apparel::TSTArmorMkII" />
+			<Item Stack="1" Name="AZA Suit" ID="classes.Items.Armor::ArmstrongSuitBlue" />
+			<Item Stack="1" Name="UVA Suit" ID="classes.Items.Armor::ArmstrongSuitViolet" />
+			<Item Stack="1" Name="PWA Suit" ID="classes.Items.Armor::ArmstrongSuitWhite" />
+			<Item Stack="1" Name="C.Armor" ID="classes.Items.Armor::ChitinArmor" />
+			<Item Stack="1" Name="C.Plate" ID="classes.Items.Armor::ChitPlate" />
+			<Item Stack="1" Name="Goo Armor" ID="classes.Items.Armor::GooArmor" />
+			<Item Stack="1" Name="M.Suit" ID="classes.Items.Armor::MirroredJumpsuit" />
+			<Item Stack="1" Name="N.Chain" ID="classes.Items.Armor::NyreanChain" />
+			<Item Stack="1" Name="P.Plate" ID="classes.Items.Armor::PolishedPlate" />
+			<Item Stack="1" Name="Void Plates" ID="classes.Items.Armor::VoidPlateArmor" />
+			<Item Stack="1" Name="I.Coat" ID="classes.Items.Armor::InsulatedCoat" />
+			<Item Stack="1" Name="WM Coat" ID="classes.Items.Armor::WeavemailCoat" />
+			<Item Stack="1" Name="WM Dress" ID="classes.Items.Armor::WeavemailDress" />
+			<Item Stack="1" Name="WM Shirt" ID="classes.Items.Armor::WeavemailShirt" />
+			<Item Stack="1" Name="O.Collar" ID="classes.Items.Armor.Unique::OmnisuitCollar" />
+			<Item Stack="1" Name="O.Suit" ID="classes.Items.Armor.Unique::Omnisuit" />
+			<Item Stack="1" Name="S.Collar" ID="classes.Items.Armor.Unique::StrangeCollar" />
+		</ItemType>
+		<ItemType Name="UpperUndergarment">
+			<Item Stack="1" Name="BikiniTop" ID="classes.Items.Apparel::FrillyBikiniTop" />
+			<Item Stack="1" Name="NetTop" ID="classes.Items.Apparel::FishnetTop" />
+			<Item Stack="1" Name="F.Bra" ID="classes.Items.Apparel::FurryBra" />
+			<Item Stack="1" Name="Babydoll" ID="classes.Items.Apparel::Babydoll" />
+			<Item Stack="1" Name="Bounty Bra" ID="classes.Items.Apparel::BountyBra" />
+			<Item Stack="1" Name="CrnyShirtV1" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt" >
+				<ItemField ID="hasRandomProperties" type="bool" value="true" />
+				<ItemField ID="varient" type="int" value="1" />
+			</Item>
+			<Item Stack="1" Name="CrnyShirtV2" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt" >
+				<ItemField ID="hasRandomProperties" type="bool" value="true" />
+				<ItemField ID="varient" type="int" value="2" />
+			</Item>
+			<Item Stack="1" Name="CrnyShirtV3" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt" >
+				<ItemField ID="hasRandomProperties" type="bool" value="true" />
+				<ItemField ID="varient" type="int" value="3" />
+			</Item>
+			<Item Stack="1" Name="CrnyShirtV4" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt" >
+				<ItemField ID="hasRandomProperties" type="bool" value="true" />
+				<ItemField ID="varient" type="int" value="4" />
+			</Item>
+			<Item Stack="1" Name="CrnyShirtV5" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt" >
+				<ItemField ID="hasRandomProperties" type="bool" value="true" />
+				<ItemField ID="varient" type="int" value="5" />
+			</Item>
+			<Item Stack="1" Name="CrnyShirtV6" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt" >
+				<ItemField ID="hasRandomProperties" type="bool" value="true" />
+				<ItemField ID="varient" type="int" value="6" />
+			</Item>
+			<Item Stack="1" Name="Corset" ID="classes.Items.Apparel::Corset" />
+			<Item Stack="1" Name="Cow Bra" ID="classes.Items.Apparel::CowPrintBra" />
+			<Item Stack="1" Name="CowShirt" ID="classes.Items.Apparel::CowPrintedShirt" />
+			<Item Stack="1" Name="Girly Bra" ID="classes.Items.Apparel::GirlyBra" />
+			<Item Stack="1" Name="Harness" ID="classes.Items.Apparel::Harness" />
+			<Item Stack="1" Name="HoneyBra" ID="classes.Items.Apparel::HoneypotBra" />
+			<Item Stack="1" Name="Lacy Bra" ID="classes.Items.Apparel::LacyBra" />
+			<Item Stack="1" Name="LilG.Bra" ID="classes.Items.Apparel::LittleGreenBra" />
+			<Item Stack="1" Name="LilG.Tee" ID="classes.Items.Apparel::LittleGreenShirt" />
+			<Item Stack="1" Name="LilG.Tank" ID="classes.Items.Apparel::LittleGreenTankTop" />
+			<Item Stack="1" Name="M.Shirt" ID="classes.Items.Apparel::MeshShirt" />
+			<Item Stack="1" Name="Pasties" ID="classes.Items.Apparel::Pasties" />
+			<Item Stack="1" Name="Bra" ID="classes.Items.Apparel::PlainBra" />
+			<Item Stack="1" Name="Undershirt" ID="classes.Items.Apparel::PlainUndershirt" />
+			<Item Stack="1" Name="Shibari Top" ID="classes.Items.Apparel::ShibariTop" />
+			<Item Stack="1" Name="Sk.Bra" ID="classes.Items.Apparel::SkullPatternBra" />
+			<Item Stack="1" Name="Sports Bra" ID="classes.Items.Apparel::SportsBra" />
+			<Item Stack="1" Name="Underbust Corset" ID="classes.Items.Apparel::UnderbustCorset" />
+			<Item Stack="1" Name="Undershirt" ID="classes.Items.Apparel::Undershirt" />
+		</ItemType>
+		<ItemType Name="LowerUndergarment">
+			<Item Stack="1" Name="BikiniBtm" ID="classes.Items.Apparel::FrillyBikiniBottom" />
+			<Item Stack="1" Name="BaggyShorts" ID="classes.Items.Apparel::BaggySwimShorts" />
+			<Item Stack="1" Name="Boxers" ID="classes.Items.Apparel::Boxers" />
+			<Item Stack="1" Name="Boyshorts" ID="classes.Items.Apparel::Boyshorts" />
+			<Item Stack="1" Name="BullStrap" ID="classes.Items.Apparel::BullsJockstrap" />
+			<Item Stack="1" Name="CockPasty" ID="classes.Items.Apparel::CockPasty" />
+			<Item Stack="1" Name="Cow Bottom" ID="classes.Items.Apparel::CowPrintBikiniBottom" />
+			<Item Stack="1" Name="Cow Panties" ID="classes.Items.Apparel::CowPrintPantiesAndGarter" />
+			<Item Stack="1" Name="CowShorts" ID="classes.Items.Apparel::CowPrintedShorts" />
+			<Item Stack="1" Name="C.String" ID="classes.Items.Apparel::CString" />
+			<Item Stack="1" Name="NetBriefs" ID="classes.Items.Apparel::FishnetBriefs" />
+			<Item Stack="1" Name="G.Panties" ID="classes.Items.Apparel::GirlyPanties" />
+			<Item Stack="1" Name="HorseBxs" ID="classes.Items.Apparel::HorseshoeBoxers" />
+			<Item Stack="1" Name="LilG.Brief" ID="classes.Items.Apparel::LittleGreenBriefs" />
+			<Item Stack="1" Name="LilG.Panty" ID="classes.Items.Apparel::LittleGreenPanties" />
+			<Item Stack="1" Name="LilG.Thong" ID="classes.Items.Apparel::LittleGreenThong" />
+			<Item Stack="1" Name="M.Thong" ID="classes.Items.Apparel::MaleThong" />
+			<Item Stack="1" Name="GuyTights" ID="classes.Items.Apparel::MaleTights" />
+			<Item Stack="1" Name="Briefs" ID="classes.Items.Apparel::PlainBriefs" />
+			<Item Stack="1" Name="Panties" ID="classes.Items.Apparel::PlainPanties" />
+			<Item Stack="1" Name="ShibariBottom" ID="classes.Items.Apparel::ShibariBottom" />
+			<Item Stack="1" Name="Stockings" ID="classes.Items.Apparel::Stockings" />
+			<Item Stack="1" Name="ThmUndies" ID="classes.Items.Apparel::ThermalUnderwear" />
+			<Item Stack="1" Name="Thong" ID="classes.Items.Apparel::Thong" />
+			<Item Stack="1" Name="Z.Pouch" ID="classes.Items.Apparel::ZipPouch" />
+		</ItemType>
+		<ItemType Name="Consumable">
+			<Item Stack="5" Name="Crystal S." ID="classes.Items.Combat::CrystalShard" />
+			<Item Stack="1" Name="H.Wine" ID="classes.Items.Drinks::HoneyWine" />
+			<Item Stack="10" Name="R.Venom" ID="classes.Items.Drinks::RedMyrVenom" />
+			<Item Stack="10" Name="Anusoft" ID="classes.Items.Miscellaneous::Anusoft" />
+			<Item Stack="10" Name="AusarTreat" ID="classes.Items.Miscellaneous::AusarTreats" />
+			<Item Stack="10" Name="BBQ To-Go" ID="classes.Items.Miscellaneous::BBQToGo" />
+			<Item Stack="50" Name="Boobswell P." ID="classes.Items.Miscellaneous::BoobswellPads" />
+			<Item Stack="10" Name="Chocolac" ID="classes.Items.Miscellaneous::Chocolac" />
+			<Item Stack="10" Name="Condensol" ID="classes.Items.Miscellaneous::Condensol" />
+			<Item Stack="10" Name="Dumbfuck" ID="classes.Items.Miscellaneous::Dumbfuck" />
+			<Item Stack="10" Name="EasyFit" ID="classes.Items.Miscellaneous::EasyFit" />
+			<Item Stack="10" Name="Estrobloom" ID="classes.Items.Miscellaneous::Estrobloom" />
+			<Item Stack="10" Name="Fertite+" ID="classes.Items.Miscellaneous::FertitePlus" />
+			<Item Stack="10" Name="FocusPill" ID="classes.Items.Miscellaneous::FocusPill" />
+			<Item Stack="5" Name="F.Extract" ID="classes.Items.Miscellaneous::FungalExtract" />
+			<Item Stack="5" Name="G.M.Bots" ID="classes.Items.Miscellaneous::GrayMicrobots" />
+			<Item Stack="10" Name="Honeydew" ID="classes.Items.Miscellaneous::Honeydew" />
+			<Item Stack="10" Name="Honeypot" ID="classes.Items.Miscellaneous::Honeypot" />
+			<Item Stack="10" Name="Honeyseed" ID="classes.Items.Miscellaneous::HoneySeed" />
+			<Item Stack="10" Name="Horse-Cock" ID="classes.Items.Miscellaneous::HorseCock" />
+			<Item Stack="10" Name="HorsePill" ID="classes.Items.Miscellaneous::HorsePill" />
+			<Item Stack="10" Name="ImmBoost" ID="classes.Items.Miscellaneous::ImmunoBooster" />
+			<Item Stack="10" Name="K.Crunch" ID="classes.Items.Miscellaneous::Kalocrunch" />
+			<Item Stack="10" Name="KnotAProb" ID="classes.Items.Miscellaneous::KnotAProblem" />
+			<Item Stack="10" Name="Lactaid" ID="classes.Items.Miscellaneous::Lactaid" />
+			<Item Stack="10" Name="LactaidMT" ID="classes.Items.Miscellaneous::LactaidMilkTank" />
+			<Item Stack="10" Name="LactaidO" ID="classes.Items.Miscellaneous::LactaidOverdrive" />
+			<Item Stack="12" Name="LargeEgg" ID="classes.Items.Miscellaneous::LargeEgg" />
+			<Item Stack="10" Name="M.Mango" ID="classes.Items.Miscellaneous::MhengaMango" />
+			<Item Stack="10" Name="M.Tight" ID="classes.Items.Miscellaneous::MightyTight" />
+			<Item Stack="50" Name="Milk Gushers" ID="classes.Items.Miscellaneous::MilkCaramelGushers" />
+			<Item Stack="50" Name="Milk. Aid" ID="classes.Items.Miscellaneous::MilkmaidsAid" />
+			<Item Stack="10" Name="MyrNectr" ID="classes.Items.Miscellaneous::MyrNectar" />
+			<Item Stack="10" Name="NaleenNip" ID="classes.Items.Miscellaneous::NaleenNip" />
+			<Item Stack="10" Name="Nuki C." ID="classes.Items.Miscellaneous::NukiCookies" />
+			<Item Stack="10" Name="OS StimBoost" ID="classes.Items.Miscellaneous::OSStimBoost" />
+			<Item Stack="10" Name="Ovilium" ID="classes.Items.Miscellaneous::Ovilium" />
+			<Item Stack="10" Name="Pandaneen" ID="classes.Items.Miscellaneous::Pandaneen" />
+			<Item Stack="10" Name="Panda Pro" ID="classes.Items.Miscellaneous::PandaPro" />
+			<Item Stack="10" Name="Priapin" ID="classes.Items.Miscellaneous::Priapin" />
+			<Item Stack="20" Name="Goblin P." ID="classes.Items.Miscellaneous::ProphylacticGoblin" />
+			<Item Stack="20" Name="LapinaraP" ID="classes.Items.Miscellaneous::ProphylacticLapinara" />
+			<Item Stack="20" Name="Rask P." ID="classes.Items.Miscellaneous::ProphylacticRaskvel" />
+			<Item Stack="20" Name="Sydian P." ID="classes.Items.Miscellaneous::ProphylacticSydian" />
+			<Item Stack="10" Name="Pussybloom" ID="classes.Items.Miscellaneous::Pussybloom" />
+			<Item Stack="10" Name="Pussyblossom" ID="classes.Items.Miscellaneous::Pussyblossom" />
+			<Item Stack="20" Name="Rainbotox" ID="classes.Items.Miscellaneous::Rainbotox" />
+			<Item Stack="5" Name="S.Booster" ID="classes.Items.Miscellaneous::ShieldBooster" />
+			<Item Stack="10" Name="SkySap" ID="classes.Items.Miscellaneous::SkySap" />
+			<Item Stack="12" Name="SmallEgg" ID="classes.Items.Miscellaneous::SmallEgg" />
+			<Item Stack="10" Name="Sterilex" ID="classes.Items.Miscellaneous::Sterilex" />
+			<Item Stack="1" Name="S.Egg" ID="classes.Items.Miscellaneous::StrangeEgg" />
+			<Item Stack="10" Name="SynthSap" ID="classes.Items.Miscellaneous::SynthSap" />
+			<Item Stack="10" Name="Human T." ID="classes.Items.Miscellaneous::TerranTreats" />
+			<Item Stack="10" Name="HP Boost" ID="classes.Items.Miscellaneous::TestHPBooster" />
+			<Item Stack="20" Name="Throbb" ID="classes.Items.Miscellaneous::Throbb" />
+			<Item Stack="10" Name="Tittyblossom" ID="classes.Items.Miscellaneous::Tittyblossom" />
+			<Item Stack="10" Name="Treatment" ID="classes.Items.Miscellaneous::Treatment" />
+			<Item Stack="10" Name="UthraSap" ID="classes.Items.Miscellaneous::UthraSap" />
+			<Item Stack="10" Name="VenusPod" ID="classes.Items.Miscellaneous::VenusPod" />
+			<Item Stack="10" Name="YT.Lube" ID="classes.Items.Miscellaneous::YTRLube" />
+			<Item Stack="10" Name="ZilHoney" ID="classes.Items.Miscellaneous::ZilHoney" />
+			<Item Stack="10" Name="ZilRation" ID="classes.Items.Miscellaneous::ZilRation" />
+			<Item Stack="10" Name="P.Saliva" ID="classes.Items.Recovery::PexigaSaliva" />
+			<Item Stack="5" Name="S.Boost M2" ID="classes.Items.Recovery::ShieldBoosterMkII" />
+			<Item Stack="1" Name="H.Bubble" ID="classes.Items.Toys.Bubbles::HugeCumBubble" />
+			<Item Stack="5" Name="L.Bubble" ID="classes.Items.Toys.Bubbles::LargeCumBubble" />
+			<Item Stack="10" Name="M.Bubble" ID="classes.Items.Toys.Bubbles::MediumCumBubble" />
+			<Item Stack="20" Name="S.Bubble" ID="classes.Items.Toys.Bubbles::SmallCumBubble" />
+			<Item Stack="5" Name="BGreenPot" ID="classes.Items.Transformatives::BigGreenPotion" />
+			<Item Stack="10" Name="Bovinium" ID="classes.Items.Transformatives::Bovinium" />
+			<Item Stack="10" Name="BumpyRd." ID="classes.Items.Transformatives::BumpyRoad" />
+			<Item Stack="10" Name="Catnip" ID="classes.Items.Transformatives::Catnip" />
+			<Item Stack="10" Name="Cerespirin" ID="classes.Items.Transformatives::Cerespirin" />
+			<Item Stack="10" Name="Circumser" ID="classes.Items.Transformatives::Circumscriber" />
+			<Item Stack="10" Name="ClearYu" ID="classes.Items.Transformatives::ClearYu" />
+			<Item Stack="10" Name="Clippex" ID="classes.Items.Transformatives::Clippex" />
+			<Item Stack="10" Name="DendroGro" ID="classes.Items.Transformatives::DendroGro" />
+			<Item Stack="10" Name="Dong D." ID="classes.Items.Transformatives::DongDesigner" />
+			<Item Stack="10" Name="Dove Balm" ID="classes.Items.Transformatives::DoveBalm" />
+			<Item Stack="10" Name="DracoG." ID="classes.Items.Transformatives::DracoGuard" />
+			<Item Stack="10" Name="Equilicum" ID="classes.Items.Transformatives::Equilicum" />
+			<Item Stack="24" Name="Lg.BluEgg" ID="classes.Items.Transformatives::EggBlueLarge" />
+			<Item Stack="24" Name="Sm.BluEgg" ID="classes.Items.Transformatives::EggBlueSmall" />
+			<Item Stack="24" Name="Lg.PinkEgg" ID="classes.Items.Transformatives::EggPinkLarge" />
+			<Item Stack="24" Name="Sm.PinkEgg" ID="classes.Items.Transformatives::EggPinkSmall" />
+			<Item Stack="24" Name="Lg.WhtEgg" ID="classes.Items.Transformatives::EggWhiteLarge" />
+			<Item Stack="24" Name="Sm.WhtEgg" ID="classes.Items.Transformatives::EggWhiteSmall" />
+			<Item Stack="1" Name="Foxfire" ID="classes.Items.Transformatives::Foxfire" />
+			<Item Stack="1" Name="Frostfire" ID="classes.Items.Transformatives::Frostfire" />
+			<Item Stack="10" Name="GaloMax" ID="classes.Items.Transformatives::GaloMax" />
+			<Item Stack="10" Name="Goblinola" ID="classes.Items.Transformatives::Goblinola" />
+			<Item Stack="10" Name="Gold Pill" ID="classes.Items.Transformatives::GoldPill" />
+			<Item Stack="10" Name="BlueGB" ID="classes.Items.Transformatives::GooBallBlue" />
+			<Item Stack="10" Name="GreenGB" ID="classes.Items.Transformatives::GooBallGreen" />
+			<Item Stack="10" Name="Orng.GB" ID="classes.Items.Transformatives::GooBallOrange" />
+			<Item Stack="10" Name="Pink GB" ID="classes.Items.Transformatives::GooBallPink" />
+			<Item Stack="10" Name="Purp.GB" ID="classes.Items.Transformatives::GooBallPurple" />
+			<Item Stack="10" Name="Red GB" ID="classes.Items.Transformatives::GooBallRed" />
+			<Item Stack="10" Name="Yellow GB" ID="classes.Items.Transformatives::GooBallYellow" />
+			<Item Stack="10" Name="Gush" ID="classes.Items.Transformatives::Gush" />
+			<Item Stack="10" Name="H-izer" ID="classes.Items.Transformatives::Honeyizer" />
+			<Item Stack="10" Name="Hornitol" ID="classes.Items.Transformatives::Hornitol" />
+			<Item Stack="10" Name="HuskarTreat" ID="classes.Items.Transformatives::HuskarTreats" />
+			<Item Stack="10" Name="J.Trunk" ID="classes.Items.Transformatives::JunkTrunk" />
+			<Item Stack="10" Name="Kero.Ven." ID="classes.Items.Transformatives::KerokorasVenom" />
+			<Item Stack="10" Name="Lucifier" ID="classes.Items.Transformatives::Lucifier" />
+			<Item Stack="10" Name="ManUp" ID="classes.Items.Transformatives::ManUp" />
+			<Item Stack="10" Name="MinoCharge" ID="classes.Items.Transformatives::MinoCharge" />
+			<Item Stack="10" Name="Nepeta" ID="classes.Items.Transformatives::Nepeta" />
+			<Item Stack="10" Name="N.Butter" ID="classes.Items.Transformatives::NukiNutbutter" />
+			<Item Stack="10" Name="Nutnog" ID="classes.Items.Transformatives::Nutnog" />
+			<Item Stack="10" Name="N.Candy" ID="classes.Items.Transformatives::NyreanCandy" />
+			<Item Stack="10" Name="Orange P." ID="classes.Items.Transformatives::OrangePill" />
+			<Item Stack="10" Name="OvirAce" ID="classes.Items.Transformatives::OvirAce" />
+			<Item Stack="5" Name="Ovir+" ID="classes.Items.Transformatives::OvirPositive" />
+			<Item Stack="10" Name="Peckermint" ID="classes.Items.Transformatives::Peckermint" />
+			<Item Stack="10" Name="RainbowG." ID="classes.Items.Transformatives::RainbowGaze" />
+			<Item Stack="10" Name="Red Pill" ID="classes.Items.Transformatives::RedPill" />
+			<Item Stack="10" Name="R.Made" ID="classes.Items.Transformatives::RubberMade" />
+			<Item Stack="10" Name="Ruskvel" ID="classes.Items.Transformatives::Ruskvel" />
+			<Item Stack="10" Name="JawBreakr" ID="classes.Items.Transformatives::SaltyJawBreaker" />
+			<Item Stack="10" Name="Semens F." ID="classes.Items.Transformatives::SemensFriend" />
+			<Item Stack="12" Name="Suma" ID="classes.Items.Transformatives::SumaCream" />
+			<Item Stack="12" Name="Suma Blk." ID="classes.Items.Transformatives::SumaCreamBlack" />
+			<Item Stack="12" Name="Suma" ID="classes.Items.Transformatives::SumaCreamWhite" />
+			<Item Stack="10" Name="SwtSweat" ID="classes.Items.Transformatives::SweetSweat" />
+			<Item Stack="10" Name="Sylvanol" ID="classes.Items.Transformatives::Sylvanol" />
+			<Item Stack="10" Name="T.Neck" ID="classes.Items.Transformatives::Turtleneck" />
+			<Item Stack="10" Name="Virection" ID="classes.Items.Transformatives::Virection" />
+		</ItemType>
+		<ItemType Name="Gadget">
+			<Item Stack="10" Name="A.Cock" ID="classes.Items.Miscellaneous::ACock" />
+			<Item Stack="10" Name="A.D.Cock" ID="classes.Items.Miscellaneous::ADCock" />
+			<Item Stack="10" Name="A.H.Cock" ID="classes.Items.Miscellaneous::AHCock" />
+			<Item Stack="1" Name="ClimbKit" ID="classes.Items.Miscellaneous::ClimbingKit" />
+			<Item Stack="10" Name="Dong D." ID="classes.Items.Transformatives::DongDesigner" />
+			<Item Stack="10" Name="Fish.Rod" ID="classes.Items.Miscellaneous::FishingRod" />
+			<Item Stack="10" Name="Horse-Cock" ID="classes.Items.Miscellaneous::HorseCock" />
+			<Item Stack="1" Name="Hoverboard" ID="classes.Items.Miscellaneous::Hoverboard" />
+			<Item Stack="1" Name="M.Milker" ID="classes.Items.Miscellaneous::MagicMilker" />
+			<Item Stack="10" Name="MilkBag" ID="classes.Items.Miscellaneous::MilkBag" />
+			<Item Stack="10" Name="Silicone" ID="classes.Items.Miscellaneous::Silicone" />
+			<Item Stack="10" Name="JokeBook" ID="classes.Items.Miscellaneous::TarkusJokeBook" />
+			<Item Stack="10" Name="T.Pack" ID="classes.Items.Miscellaneous::ThermalPack" />
+			<Item Stack="1" Name="Varmint" ID="classes.Items.Miscellaneous::VarmintItem" />
+			<Item Stack="1" Name="B.Buddy" ID="classes.Items.Toys::BubbleBuddy" />
+			<Item Stack="1" Name="EggTrnr" ID="classes.Items.Toys::EggTrainer" />
+			<Item Stack="1" Name="G.Cuffs" ID="classes.Items.Toys::GravCuffs" />
+			<Item Stack="1" Name="H.Hole" ID="classes.Items.Toys::HoverHole" />
+			<Item Stack="1" Name="N.B.Hole" ID="classes.Items.Toys::NivasBionaHole" />
+			<Item Stack="1" Name="T.B.Hole" ID="classes.Items.Toys::TamaniBionaHole" />
+			<Item Stack="1" Name="SukMastr" ID="classes.Items.Toys::SukMastr" />
+		</ItemType>
+		<ItemType Name="Melee Weapon">
+			<Item Stack="1" Name="BioWhip" ID="classes.Items.Melee::BioWhip" />
+			<Item Stack="1" Name="C.Saber" ID="classes.Items.Melee::CavalrySaber" />
+			<Item Stack="1" Name="Cutlass" ID="classes.Items.Melee::Cutlass" />
+			<Item Stack="1" Name="E's Hmmr" ID="classes.Items.Melee::EmmysJolthammer" LongName="Emmy's Jolthammer" />
+			<Item Stack="1" Name="E'sSaber" ID="classes.Items.Melee::EmmysLavaSaber" LongName="Emmy's Lava Saber" />
+			<Item Stack="1" Name="E's Blade" ID="classes.Items.Melee::EmmysVampBlade" LongName="Emmy's Vamp Blade" />
+			<Item Stack="1" Name="J.Hmmr." ID="classes.Items.Melee::Jolthammer" />
+			<Item Stack="1" Name="Knife" ID="classes.Items.Melee::Knife" />
+			<Item Stack="1" Name="L.Saber" ID="classes.Items.Melee::LavaSaber" />
+			<Item Stack="1" Name="Machete" ID="classes.Items.Melee::Machette" />
+			<Item Stack="1" Name="M.Pick" ID="classes.Items.Melee::MilitaryPick" />
+			<Item Stack="1" Name="M.Saber" ID="classes.Items.Melee::MonofilamentSaber" />
+			<Item Stack="1" Name="N.Spear" ID="classes.Items.Melee::NyreanSpear" />
+			<Item Stack="1" Name="P.Talons" ID="classes.Items.Melee::PredatorTalons" />
+			<Item Stack="1" Name="Wrench" ID="classes.Items.Melee::RaskvelWrench" />
+			<Item Stack="1" Name="Rock" ID="classes.Items.Melee::Rock" />
+			<Item Stack="1" Name="R.Hammer" ID="classes.Items.Melee::RocketHammer" />
+			<Item Stack="1" Name="ShockBlade" ID="classes.Items.Melee::ShockBlade" />
+			<Item Stack="1" Name="Shortsword" ID="classes.Items.Melee::Shortsword" />
+			<Item Stack="1" Name="SurvAxe" ID="classes.Items.Melee::SurvivalAxe" />
+			<Item Stack="1" Name="T.Spear" ID="classes.Items.Melee::TaivrasSpear" />
+			<Item Stack="1" Name="T.Scalpel" ID="classes.Items.Melee::ThermalScalpel" />
+			<Item Stack="1" Name="V.Blade" ID="classes.Items.Melee::VampBlade" />
+			<Item Stack="1" Name="Vanae Spear" ID="classes.Items.Melee::VanaeSpear" />
+			<Item Stack="1" Name="Warhammer" ID="classes.Items.Melee::Warhammer" />
+			<Item Stack="1" Name="Whip" ID="classes.Items.Melee::Whip" />
+			<Item Stack="1" Name="Y.Strap" ID="classes.Items.Melee::YappiStrap" />
+		</ItemType>
+		<ItemType Name="Ranged Weapon">
+			<Item Stack="1" Name="Aegis MG" ID="classes.Items.Guns::AegisLightMG" />
+			<Item Stack="1" Name="ArcCast." ID="classes.Items.Guns::ArcCaster" />
+			<Item Stack="1" Name="B.Light" ID="classes.Items.Guns::BlackLight" />
+			<Item Stack="1" Name="B.Rifle" ID="classes.Items.Guns::BoltActionRifle" />
+			<Item Stack="1" Name="Custom LP-17" ID="classes.Items.Guns::CustomLP17" LongName="Custom LP-17 Laser Pistol" />
+			<Item Stack="1" Name="E.Handgun" ID="classes.Items.Guns::EagleHandgun" />
+			<Item Stack="1" Name="Electrogun" ID="classes.Items.Guns::Electrogun" />
+			<Item Stack="1" Name="E's Pistol" ID="classes.Items.Guns::EmmysSalamanderPistol" LongName="Emmy's Salamander Pistol" />
+			<Item Stack="1" Name="E's Rifle" ID="classes.Items.Guns::EmmysSalamanderRifle" LongName="Emmy's Salamander Rifle" />
+			<Item Stack="1" Name="E's S.R." ID="classes.Items.Guns::EmmysSalamanderRifle2" LongName="Emmy's Tweaked Salamander Rifle" />
+			<Item Stack="1" Name="FlareGun" ID="classes.Items.Guns::FlareGun" />
+			<Item Stack="1" Name="Goovolver" ID="classes.Items.Guns::Goovolver" />
+			<Item Stack="1" Name="Hammer C." ID="classes.Items.Guns::HammerCarbine" />
+			<Item Stack="1" Name="Hammer Pstl." ID="classes.Items.Guns::HammerPistol" />
+			<Item Stack="1" Name="Hammer Pstl." ID="classes.Items.Guns::HammerPistolScavenged" />
+			<Item Stack="1" Name="Holdout H.P." ID="classes.Items.Guns::HoldoutHP" />
+			<Item Stack="1" Name="Hld.Pistol" ID="classes.Items.Guns::HoldOutPistol" />
+			<Item Stack="1" Name="H.Rifle" ID="classes.Items.Guns::HuntingRifle" />
+			<Item Stack="1" Name="Khans AC." ID="classes.Items.Guns::KhansArcCaster" />
+			<Item Stack="1" Name="Laser C." ID="classes.Items.Guns::LaserCarbine" />
+			<Item Stack="1" Name="LaserPistol" ID="classes.Items.Guns::LaserPistol" />
+			<Item Stack="1" Name="Mag.Pistol" ID="classes.Items.Guns::MagnumPistol" />
+			<Item Stack="1" Name="Myr Bow" ID="classes.Items.Guns::MyrBow" />
+			<Item Stack="1" Name="M.Rifle" ID="classes.Items.Guns::MyrRifle" />
+			<Item Stack="1" Name="Nova Pstl." ID="classes.Items.Guns::NovaPistol" />
+			<Item Stack="1" Name="Nova Rifle" ID="classes.Items.Guns::NovaRifle" />
+			<Item Stack="1" Name="PlasmaBore" ID="classes.Items.Guns::PlasmaBore" />
+			<Item Stack="1" Name="Plasma P." ID="classes.Items.Guns::PlasmaPistol" />
+			<Item Stack="1" Name="P.Bow" ID="classes.Items.Guns::PrimitiveBow" />
+			<Item Stack="1" Name="Royal Bow" ID="classes.Items.Guns::QueensBow" />
+			<Item Stack="1" Name="Revolvr" ID="classes.Items.Guns::RudimentaryRevolver" />
+			<Item Stack="1" Name="SalPistl" ID="classes.Items.Guns::SalamanderPistol" />
+			<Item Stack="1" Name="SalRifle" ID="classes.Items.Guns::SalamanderRifle" />
+			<Item Stack="1" Name="S.Pistol" ID="classes.Items.Guns::ScopedPistol" />
+			<Item Stack="1" Name="secureMP" ID="classes.Items.Guns::SecureMP" />
+			<Item Stack="1" Name="SlutRay" ID="classes.Items.Guns::SlutRay" />
+			<Item Stack="1" Name="A.SlutRay" ID="classes.Items.Guns::SlutRayAdvanced" />
+			<Item Stack="1" Name="SunFire" ID="classes.Items.Guns::SunFire" />
+			<Item Stack="1" Name="Tach. Beam" ID="classes.Items.Guns::TachyonBeamLaser" />
+			<Item Stack="1" Name="Tanis's Bow" ID="classes.Items.Guns::TanisBow" />
+			<Item Stack="1" Name="TheShocker" ID="classes.Items.Guns::TheShocker" />
+			<Item Stack="1" Name="Shotgn" ID="classes.Items.Guns::TrenchShotgun" />
+			<Item Stack="1" Name="ZK Rifle" ID="classes.Items.Guns::ZKRifle" />
+		</ItemType>
+		<ItemType Name="Shield">
+			<Item Stack="1" Name="AW Belt" ID="classes.Items.Protection::ArcticWarfareBelt" />
+			<Item Stack="1" Name="BasicShld" ID="classes.Items.Protection::BasicShield" />
+			<Item Stack="1" Name="DBG Shield" ID="classes.Items.Protection::DBGShield" />
+			<Item Stack="1" Name="Decent S." ID="classes.Items.Protection::DecentShield" />
+			<Item Stack="1" Name="HeatBelt" ID="classes.Items.Protection::HeatBelt" />
+			<Item Stack="1" Name="I.Shield" ID="classes.Items.Protection::ImprovisedShield" />
+			<Item Stack="1" Name="E.Shield" ID="classes.Items.Protection::JoyCoEliteShield" />
+			<Item Stack="1" Name="P.Shield" ID="classes.Items.Protection::JoyCoPremiumShield" />
+			<Item Stack="1" Name="O.Aegis" ID="classes.Items.Protection::OzoneAegis" />
+			<Item Stack="1" Name="Mark IIS" ID="classes.Items.Protection::ReaperArmamentsMarkIIShield" />
+			<Item Stack="1" Name="Mark I.S." ID="classes.Items.Protection::ReaperArmamentsMarkIShield" />
+			<Item Stack="1" Name="S.Shield" ID="classes.Items.Protection::SalamanderShield" />
+		</ItemType>
+		<ItemType Name="Other">
+			<Item Stack="10" Name="EMP Gren." ID="classes.Items.Miscellaneous::EMPGrenade" />
+			<Item Stack="10" Name="Flashbang" ID="classes.Items.Miscellaneous::FlashGrenade" />
+			<Item Stack="10" Name="T.Gren" ID="classes.Items.Miscellaneous::TestGrenade" />
+			<Item Stack="2" Name="GemSack" ID="classes.Items.Miscellaneous::GemSatchel" />
+			<Item Stack="20" Name="Kirkite" ID="classes.Items.Miscellaneous::Kirkite" />
+			<Item Stack="20" Name="Picardine" ID="classes.Items.Miscellaneous::Picardine" />
+			<Item Stack="20" Name="Satyrite" ID="classes.Items.Miscellaneous::Satyrite" />
+			<Item Stack="1" Name="V.Bloom" ID="classes.Items.Miscellaneous::VenusBloom" />
+			<Item Stack="5" Name="W.Drone" ID="classes.Items.Miscellaneous::WeatherDrone" />
+		</ItemType>
 	</Items>
 	<!-- ================================================================ -->
 	<KeyItems>

--- a/TiTsEd/TiTSEd.Data.xml
+++ b/TiTsEd/TiTSEd.Data.xml
@@ -864,29 +864,41 @@
 			<Item Stack="1" Name="F.Bra" ID="classes.Items.Apparel::FurryBra" />
 			<Item Stack="1" Name="Babydoll" ID="classes.Items.Apparel::Babydoll" />
 			<Item Stack="1" Name="Bounty Bra" ID="classes.Items.Apparel::BountyBra" />
-			<Item Stack="1" Name="CrnyShirtV1" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt" >
-				<ItemField ID="hasRandomProperties" type="bool" value="true" />
-				<ItemField ID="varient" type="int" value="1" />
+			<Item Stack="1" Name="CrnyShirtV1" ID="classes.Items.Apparel::CornyTShirt" DisplayName="Corny T-Shirt v1" >
+				<ItemOption Name="Normal">
+					<ItemField ID="hasRandomProperties" type="bool" value="true" />
+					<ItemField ID="varient" type="int" value="1" />
+				</ItemOption>
 			</Item>
-			<Item Stack="1" Name="CrnyShirtV2" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt" >
-				<ItemField ID="hasRandomProperties" type="bool" value="true" />
-				<ItemField ID="varient" type="int" value="2" />
+			<Item Stack="1" Name="CrnyShirtV2" ID="classes.Items.Apparel::CornyTShirt" DisplayName="Corny T-Shirt v2" >
+				<ItemOption Name="Normal">
+					<ItemField ID="hasRandomProperties" type="bool" value="true" />
+					<ItemField ID="varient" type="int" value="2" />
+				</ItemOption>
 			</Item>
-			<Item Stack="1" Name="CrnyShirtV3" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt" >
-				<ItemField ID="hasRandomProperties" type="bool" value="true" />
-				<ItemField ID="varient" type="int" value="3" />
+			<Item Stack="1" Name="CrnyShirtV3" ID="classes.Items.Apparel::CornyTShirt" DisplayName="Corny T-Shirt v3" >
+				<ItemOption Name="Normal">
+					<ItemField ID="hasRandomProperties" type="bool" value="true" />
+					<ItemField ID="varient" type="int" value="3" />
+				</ItemOption>
 			</Item>
-			<Item Stack="1" Name="CrnyShirtV4" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt" >
-				<ItemField ID="hasRandomProperties" type="bool" value="true" />
-				<ItemField ID="varient" type="int" value="4" />
+			<Item Stack="1" Name="CrnyShirtV4" ID="classes.Items.Apparel::CornyTShirt" DisplayName="Corny T-Shirt v4" >
+				<ItemOption Name="Normal">
+					<ItemField ID="hasRandomProperties" type="bool" value="true" />
+					<ItemField ID="varient" type="int" value="4" />
+				</ItemOption>
 			</Item>
-			<Item Stack="1" Name="CrnyShirtV5" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt" >
-				<ItemField ID="hasRandomProperties" type="bool" value="true" />
-				<ItemField ID="varient" type="int" value="5" />
+			<Item Stack="1" Name="CrnyShirtV5" ID="classes.Items.Apparel::CornyTShirt" DisplayName="Corny T-Shirt v5" >
+				<ItemOption Name="Normal">
+					<ItemField ID="hasRandomProperties" type="bool" value="true" />
+					<ItemField ID="varient" type="int" value="5" />
+				</ItemOption>
 			</Item>
-			<Item Stack="1" Name="CrnyShirtV6" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt" >
-				<ItemField ID="hasRandomProperties" type="bool" value="true" />
-				<ItemField ID="varient" type="int" value="6" />
+			<Item Stack="1" Name="CrnyShirtV6" ID="classes.Items.Apparel::CornyTShirt" DisplayName="Corny T-Shirt v6" >
+				<ItemOption Name="Normal">
+					<ItemField ID="hasRandomProperties" type="bool" value="true" />
+					<ItemField ID="varient" type="int" value="6" />
+				</ItemOption>
 			</Item>
 			<Item Stack="1" Name="Corset" ID="classes.Items.Apparel::Corset" />
 			<Item Stack="1" Name="Cow Bra" ID="classes.Items.Apparel::CowPrintBra" />
@@ -911,8 +923,20 @@
 		<ItemType Name="LowerUndergarment">
 			<Item Stack="1" Name="BikiniBtm" ID="classes.Items.Apparel::FrillyBikiniBottom" />
 			<Item Stack="1" Name="BaggyShorts" ID="classes.Items.Apparel::BaggySwimShorts" />
-			<Item Stack="1" Name="Boxers" ID="classes.Items.Apparel::Boxers" />
-			<Item Stack="1" Name="Boyshorts" ID="classes.Items.Apparel::Boyshorts" />
+			<Item Stack="1" Name="Boxers" ID="classes.Items.Apparel::Boxers">
+				<ItemOption Name="Normal" />
+				<ItemOption Name="Hardlight">
+					<ItemField ID="hasRandomProperties" type="bool" value="true" />
+					<ItemField ID="hardLightEquipped" type="bool" value="true" />
+				</ItemOption>
+			</Item>
+			<Item Stack="1" Name="Boyshorts" ID="classes.Items.Apparel::Boyshorts">
+				<ItemOption Name="Normal" />
+				<ItemOption Name="Hardlight">
+					<ItemField ID="hasRandomProperties" type="bool" value="true" />
+					<ItemField ID="hardLightEquipped" type="bool" value="true" />
+				</ItemOption>
+			</Item>
 			<Item Stack="1" Name="BullStrap" ID="classes.Items.Apparel::BullsJockstrap" />
 			<Item Stack="1" Name="CockPasty" ID="classes.Items.Apparel::CockPasty" />
 			<Item Stack="1" Name="Cow Bottom" ID="classes.Items.Apparel::CowPrintBikiniBottom" />
@@ -928,11 +952,35 @@
 			<Item Stack="1" Name="M.Thong" ID="classes.Items.Apparel::MaleThong" />
 			<Item Stack="1" Name="GuyTights" ID="classes.Items.Apparel::MaleTights" />
 			<Item Stack="1" Name="Briefs" ID="classes.Items.Apparel::PlainBriefs" />
-			<Item Stack="1" Name="Panties" ID="classes.Items.Apparel::PlainPanties" />
-			<Item Stack="1" Name="ShibariBottom" ID="classes.Items.Apparel::ShibariBottom" />
-			<Item Stack="1" Name="Stockings" ID="classes.Items.Apparel::Stockings" />
+			<Item Stack="1" Name="Panties" ID="classes.Items.Apparel::PlainPanties">
+				<ItemOption Name="Normal" />
+				<ItemOption Name="Hardlight">
+					<ItemField ID="hasRandomProperties" type="bool" value="true" />
+					<ItemField ID="hardLightEquipped" type="bool" value="true" />
+				</ItemOption>
+			</Item>
+			<Item Stack="1" Name="ShibariBottom" ID="classes.Items.Apparel::ShibariBottom">
+				<ItemOption Name="Normal" />
+				<ItemOption Name="Hardlight">
+					<ItemField ID="hasRandomProperties" type="bool" value="true" />
+					<ItemField ID="hardLightEquipped" type="bool" value="true" />
+				</ItemOption>
+			</Item>
+			<Item Stack="1" Name="Stockings" ID="classes.Items.Apparel::Stockings">
+				<ItemOption Name="Normal" />
+				<ItemOption Name="Hardlight">
+					<ItemField ID="hasRandomProperties" type="bool" value="true" />
+					<ItemField ID="hardLightEquipped" type="bool" value="true" />
+				</ItemOption>
+			</Item>
 			<Item Stack="1" Name="ThmUndies" ID="classes.Items.Apparel::ThermalUnderwear" />
-			<Item Stack="1" Name="Thong" ID="classes.Items.Apparel::Thong" />
+			<Item Stack="1" Name="Thong" ID="classes.Items.Apparel::Thong">
+				<ItemOption Name="Normal" />
+				<ItemOption Name="Hardlight">
+					<ItemField ID="hasRandomProperties" type="bool" value="true" />
+					<ItemField ID="hardLightEquipped" type="bool" value="true" />
+				</ItemOption>
+			</Item>
 			<Item Stack="1" Name="Z.Pouch" ID="classes.Items.Apparel::ZipPouch" />
 		</ItemType>
 		<ItemType Name="Consumable">
@@ -1094,9 +1142,9 @@
 			<Item Stack="1" Name="BioWhip" ID="classes.Items.Melee::BioWhip" />
 			<Item Stack="1" Name="C.Saber" ID="classes.Items.Melee::CavalrySaber" />
 			<Item Stack="1" Name="Cutlass" ID="classes.Items.Melee::Cutlass" />
-			<Item Stack="1" Name="E's Hmmr" ID="classes.Items.Melee::EmmysJolthammer" LongName="Emmy's Jolthammer" />
-			<Item Stack="1" Name="E'sSaber" ID="classes.Items.Melee::EmmysLavaSaber" LongName="Emmy's Lava Saber" />
-			<Item Stack="1" Name="E's Blade" ID="classes.Items.Melee::EmmysVampBlade" LongName="Emmy's Vamp Blade" />
+			<Item Stack="1" Name="E's Hmmr" ID="classes.Items.Melee::EmmysJolthammer" DisplayName="Emmy's Jolthammer" />
+			<Item Stack="1" Name="E'sSaber" ID="classes.Items.Melee::EmmysLavaSaber" DisplayName="Emmy's Lava Saber" />
+			<Item Stack="1" Name="E's Blade" ID="classes.Items.Melee::EmmysVampBlade" DisplayName="Emmy's Vamp Blade" />
 			<Item Stack="1" Name="J.Hmmr." ID="classes.Items.Melee::Jolthammer" />
 			<Item Stack="1" Name="Knife" ID="classes.Items.Melee::Knife" />
 			<Item Stack="1" Name="L.Saber" ID="classes.Items.Melee::LavaSaber" />
@@ -1124,12 +1172,12 @@
 			<Item Stack="1" Name="ArcCast." ID="classes.Items.Guns::ArcCaster" />
 			<Item Stack="1" Name="B.Light" ID="classes.Items.Guns::BlackLight" />
 			<Item Stack="1" Name="B.Rifle" ID="classes.Items.Guns::BoltActionRifle" />
-			<Item Stack="1" Name="Custom LP-17" ID="classes.Items.Guns::CustomLP17" LongName="Custom LP-17 Laser Pistol" />
+			<Item Stack="1" Name="Custom LP-17" ID="classes.Items.Guns::CustomLP17" DisplayName="Custom LP-17 Laser Pistol" />
 			<Item Stack="1" Name="E.Handgun" ID="classes.Items.Guns::EagleHandgun" />
 			<Item Stack="1" Name="Electrogun" ID="classes.Items.Guns::Electrogun" />
-			<Item Stack="1" Name="E's Pistol" ID="classes.Items.Guns::EmmysSalamanderPistol" LongName="Emmy's Salamander Pistol" />
-			<Item Stack="1" Name="E's Rifle" ID="classes.Items.Guns::EmmysSalamanderRifle" LongName="Emmy's Salamander Rifle" />
-			<Item Stack="1" Name="E's S.R." ID="classes.Items.Guns::EmmysSalamanderRifle2" LongName="Emmy's Tweaked Salamander Rifle" />
+			<Item Stack="1" Name="E's Pistol" ID="classes.Items.Guns::EmmysSalamanderPistol" DisplayName="Emmy's Salamander Pistol" />
+			<Item Stack="1" Name="E's Rifle" ID="classes.Items.Guns::EmmysSalamanderRifle" DisplayName="Emmy's Salamander Rifle" />
+			<Item Stack="1" Name="E's S.R." ID="classes.Items.Guns::EmmysSalamanderRifle2" DisplayName="Emmy's Tweaked Salamander Rifle" />
 			<Item Stack="1" Name="FlareGun" ID="classes.Items.Guns::FlareGun" />
 			<Item Stack="1" Name="Goovolver" ID="classes.Items.Guns::Goovolver" />
 			<Item Stack="1" Name="Hammer C." ID="classes.Items.Guns::HammerCarbine" />

--- a/TiTsEd/TiTSEd.Data.xml
+++ b/TiTsEd/TiTSEd.Data.xml
@@ -915,11 +915,13 @@
 			<Item Stack="1" Name="Boxers" ID="classes.Items.Apparel::Boxers" LongName="Boxers HL" Tooltip="Hardlight Version">
 				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
 				<ItemField Name="hardLightEquipped" Type="bool" Value="true" />
+				<ItemField Name="basePrice" Type="int" Value="3130" />
 			</Item>
 			<Item Stack="1" Name="Boyshorts" ID="classes.Items.Apparel::Boyshorts" />
 			<Item Stack="1" Name="Boyshorts" ID="classes.Items.Apparel::Boyshorts" LongName="Boyshorts HL" Tooltip="Hardlight Version">
 				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
 				<ItemField Name="hardLightEquipped" Type="bool" Value="true" />
+				<ItemField Name="basePrice" Type="int" Value="3180" />
 			</Item>
 			<Item Stack="1" Name="BullStrap" ID="classes.Items.Apparel::BullsJockstrap" />
 			<Item Stack="1" Name="CockPasty" ID="classes.Items.Apparel::CockPasty" />
@@ -940,22 +942,26 @@
 			<Item Stack="1" Name="Panties" ID="classes.Items.Apparel::PlainPanties" LongName="Plain Panties HL" Tooltip="Hardlight Version">
 				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
 				<ItemField Name="hardLightEquipped" Type="bool" Value="true" />
+				<ItemField Name="basePrice" Type="int" Value="3040" />
 			</Item>
 			<Item Stack="1" Name="ShibariBottom" ID="classes.Items.Apparel::ShibariBottom" />
 			<Item Stack="1" Name="ShibariBottom" ID="classes.Items.Apparel::ShibariBottom" LongName="Shibari Bottom HL" Tooltip="Hardlight Version">
 				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
 				<ItemField Name="hardLightEquipped" Type="bool" Value="true" />
+				<ItemField Name="basePrice" Type="int" Value="3920" />
 			</Item>
 			<Item Stack="1" Name="Stockings" ID="classes.Items.Apparel::Stockings" />
 			<Item Stack="1" Name="Stockings" ID="classes.Items.Apparel::Stockings" LongName="Stockings HL" Tooltip="Hardlight Version">
 				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
 				<ItemField Name="hardLightEquipped" Type="bool" Value="true" />
+				<ItemField Name="basePrice" Type="int" Value="3850" />
 			</Item>
 			<Item Stack="1" Name="ThmUndies" ID="classes.Items.Apparel::ThermalUnderwear" />
 			<Item Stack="1" Name="Thong" ID="classes.Items.Apparel::Thong" />
 			<Item Stack="1" Name="Thong" ID="classes.Items.Apparel::Thong" LongName="Thong HL" Tooltip="Hardlight Version">
 				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
 				<ItemField Name="hardLightEquipped" Type="bool" Value="true" />
+				<ItemField Name="basePrice" Type="int" Value="3550" />
 			</Item>
 			<Item Stack="1" Name="Z.Pouch" ID="classes.Items.Apparel::ZipPouch" />
 		</ItemType>

--- a/TiTsEd/TiTSEd.Data.xml
+++ b/TiTsEd/TiTSEd.Data.xml
@@ -858,47 +858,35 @@
 			<Item Stack="1" Name="O.Suit" ID="classes.Items.Armor.Unique::Omnisuit" />
 			<Item Stack="1" Name="S.Collar" ID="classes.Items.Armor.Unique::StrangeCollar" />
 		</ItemType>
-		<ItemType Name="UpperUndergarment">
+		<ItemType Name="Upper Undergarment">
 			<Item Stack="1" Name="BikiniTop" ID="classes.Items.Apparel::FrillyBikiniTop" />
 			<Item Stack="1" Name="NetTop" ID="classes.Items.Apparel::FishnetTop" />
 			<Item Stack="1" Name="F.Bra" ID="classes.Items.Apparel::FurryBra" />
 			<Item Stack="1" Name="Babydoll" ID="classes.Items.Apparel::Babydoll" />
 			<Item Stack="1" Name="Bounty Bra" ID="classes.Items.Apparel::BountyBra" />
-			<Item Stack="1" Name="CrnyShirtV1" ID="classes.Items.Apparel::CornyTShirt" DisplayName="Corny T-Shirt v1" >
-				<ItemOption Name="Normal">
-					<ItemField ID="hasRandomProperties" type="bool" value="true" />
-					<ItemField ID="varient" type="int" value="1" />
-				</ItemOption>
+			<Item Stack="1" Name="CrnyShirtV1" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt v1" >
+				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
+				<ItemField Name="variant" Type="int" Value="1" />
 			</Item>
-			<Item Stack="1" Name="CrnyShirtV2" ID="classes.Items.Apparel::CornyTShirt" DisplayName="Corny T-Shirt v2" >
-				<ItemOption Name="Normal">
-					<ItemField ID="hasRandomProperties" type="bool" value="true" />
-					<ItemField ID="varient" type="int" value="2" />
-				</ItemOption>
+			<Item Stack="1" Name="CrnyShirtV2" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt v2" >
+				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
+				<ItemField Name="variant" Type="int" Value="2" />
 			</Item>
-			<Item Stack="1" Name="CrnyShirtV3" ID="classes.Items.Apparel::CornyTShirt" DisplayName="Corny T-Shirt v3" >
-				<ItemOption Name="Normal">
-					<ItemField ID="hasRandomProperties" type="bool" value="true" />
-					<ItemField ID="varient" type="int" value="3" />
-				</ItemOption>
+			<Item Stack="1" Name="CrnyShirtV3" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt v3" >
+				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
+				<ItemField Name="variant" Type="int" Value="3" />
 			</Item>
-			<Item Stack="1" Name="CrnyShirtV4" ID="classes.Items.Apparel::CornyTShirt" DisplayName="Corny T-Shirt v4" >
-				<ItemOption Name="Normal">
-					<ItemField ID="hasRandomProperties" type="bool" value="true" />
-					<ItemField ID="varient" type="int" value="4" />
-				</ItemOption>
+			<Item Stack="1" Name="CrnyShirtV4" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt v4" >
+				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
+				<ItemField Name="variant" Type="int" Value="4" />
 			</Item>
-			<Item Stack="1" Name="CrnyShirtV5" ID="classes.Items.Apparel::CornyTShirt" DisplayName="Corny T-Shirt v5" >
-				<ItemOption Name="Normal">
-					<ItemField ID="hasRandomProperties" type="bool" value="true" />
-					<ItemField ID="varient" type="int" value="5" />
-				</ItemOption>
+			<Item Stack="1" Name="CrnyShirtV5" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt v5" >
+				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
+				<ItemField Name="variant" Type="int" Value="5" />
 			</Item>
-			<Item Stack="1" Name="CrnyShirtV6" ID="classes.Items.Apparel::CornyTShirt" DisplayName="Corny T-Shirt v6" >
-				<ItemOption Name="Normal">
-					<ItemField ID="hasRandomProperties" type="bool" value="true" />
-					<ItemField ID="varient" type="int" value="6" />
-				</ItemOption>
+			<Item Stack="1" Name="CrnyShirtV6" ID="classes.Items.Apparel::CornyTShirt" LongName="Corny T-Shirt v6" >
+				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
+				<ItemField Name="variant" Type="int" Value="6" />
 			</Item>
 			<Item Stack="1" Name="Corset" ID="classes.Items.Apparel::Corset" />
 			<Item Stack="1" Name="Cow Bra" ID="classes.Items.Apparel::CowPrintBra" />
@@ -920,22 +908,18 @@
 			<Item Stack="1" Name="Underbust Corset" ID="classes.Items.Apparel::UnderbustCorset" />
 			<Item Stack="1" Name="Undershirt" ID="classes.Items.Apparel::Undershirt" />
 		</ItemType>
-		<ItemType Name="LowerUndergarment">
+		<ItemType Name="Lower Undergarment">
 			<Item Stack="1" Name="BikiniBtm" ID="classes.Items.Apparel::FrillyBikiniBottom" />
 			<Item Stack="1" Name="BaggyShorts" ID="classes.Items.Apparel::BaggySwimShorts" />
-			<Item Stack="1" Name="Boxers" ID="classes.Items.Apparel::Boxers">
-				<ItemOption Name="Normal" />
-				<ItemOption Name="Hardlight">
-					<ItemField ID="hasRandomProperties" type="bool" value="true" />
-					<ItemField ID="hardLightEquipped" type="bool" value="true" />
-				</ItemOption>
+			<Item Stack="1" Name="Boxers" ID="classes.Items.Apparel::Boxers" />
+			<Item Stack="1" Name="Boxers" ID="classes.Items.Apparel::Boxers" LongName="Boxers HL" Tooltip="Hardlight Version">
+				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
+				<ItemField Name="hardLightEquipped" Type="bool" Value="true" />
 			</Item>
-			<Item Stack="1" Name="Boyshorts" ID="classes.Items.Apparel::Boyshorts">
-				<ItemOption Name="Normal" />
-				<ItemOption Name="Hardlight">
-					<ItemField ID="hasRandomProperties" type="bool" value="true" />
-					<ItemField ID="hardLightEquipped" type="bool" value="true" />
-				</ItemOption>
+			<Item Stack="1" Name="Boyshorts" ID="classes.Items.Apparel::Boyshorts" />
+			<Item Stack="1" Name="Boyshorts" ID="classes.Items.Apparel::Boyshorts" LongName="Boyshorts HL" Tooltip="Hardlight Version">
+				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
+				<ItemField Name="hardLightEquipped" Type="bool" Value="true" />
 			</Item>
 			<Item Stack="1" Name="BullStrap" ID="classes.Items.Apparel::BullsJockstrap" />
 			<Item Stack="1" Name="CockPasty" ID="classes.Items.Apparel::CockPasty" />
@@ -952,34 +936,26 @@
 			<Item Stack="1" Name="M.Thong" ID="classes.Items.Apparel::MaleThong" />
 			<Item Stack="1" Name="GuyTights" ID="classes.Items.Apparel::MaleTights" />
 			<Item Stack="1" Name="Briefs" ID="classes.Items.Apparel::PlainBriefs" />
-			<Item Stack="1" Name="Panties" ID="classes.Items.Apparel::PlainPanties">
-				<ItemOption Name="Normal" />
-				<ItemOption Name="Hardlight">
-					<ItemField ID="hasRandomProperties" type="bool" value="true" />
-					<ItemField ID="hardLightEquipped" type="bool" value="true" />
-				</ItemOption>
+			<Item Stack="1" Name="Panties" ID="classes.Items.Apparel::PlainPanties" />
+			<Item Stack="1" Name="Panties" ID="classes.Items.Apparel::PlainPanties" LongName="Plain Panties HL" Tooltip="Hardlight Version">
+				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
+				<ItemField Name="hardLightEquipped" Type="bool" Value="true" />
 			</Item>
-			<Item Stack="1" Name="ShibariBottom" ID="classes.Items.Apparel::ShibariBottom">
-				<ItemOption Name="Normal" />
-				<ItemOption Name="Hardlight">
-					<ItemField ID="hasRandomProperties" type="bool" value="true" />
-					<ItemField ID="hardLightEquipped" type="bool" value="true" />
-				</ItemOption>
+			<Item Stack="1" Name="ShibariBottom" ID="classes.Items.Apparel::ShibariBottom" />
+			<Item Stack="1" Name="ShibariBottom" ID="classes.Items.Apparel::ShibariBottom" LongName="Shibari Bottom HL" Tooltip="Hardlight Version">
+				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
+				<ItemField Name="hardLightEquipped" Type="bool" Value="true" />
 			</Item>
-			<Item Stack="1" Name="Stockings" ID="classes.Items.Apparel::Stockings">
-				<ItemOption Name="Normal" />
-				<ItemOption Name="Hardlight">
-					<ItemField ID="hasRandomProperties" type="bool" value="true" />
-					<ItemField ID="hardLightEquipped" type="bool" value="true" />
-				</ItemOption>
+			<Item Stack="1" Name="Stockings" ID="classes.Items.Apparel::Stockings" />
+			<Item Stack="1" Name="Stockings" ID="classes.Items.Apparel::Stockings" LongName="Stockings HL" Tooltip="Hardlight Version">
+				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
+				<ItemField Name="hardLightEquipped" Type="bool" Value="true" />
 			</Item>
 			<Item Stack="1" Name="ThmUndies" ID="classes.Items.Apparel::ThermalUnderwear" />
-			<Item Stack="1" Name="Thong" ID="classes.Items.Apparel::Thong">
-				<ItemOption Name="Normal" />
-				<ItemOption Name="Hardlight">
-					<ItemField ID="hasRandomProperties" type="bool" value="true" />
-					<ItemField ID="hardLightEquipped" type="bool" value="true" />
-				</ItemOption>
+			<Item Stack="1" Name="Thong" ID="classes.Items.Apparel::Thong" />
+			<Item Stack="1" Name="Thong" ID="classes.Items.Apparel::Thong" LongName="Thong HL" Tooltip="Hardlight Version">
+				<ItemField Name="hasRandomProperties" Type="bool" Value="true" />
+				<ItemField Name="hardLightEquipped" Type="bool" Value="true" />
 			</Item>
 			<Item Stack="1" Name="Z.Pouch" ID="classes.Items.Apparel::ZipPouch" />
 		</ItemType>
@@ -1142,9 +1118,9 @@
 			<Item Stack="1" Name="BioWhip" ID="classes.Items.Melee::BioWhip" />
 			<Item Stack="1" Name="C.Saber" ID="classes.Items.Melee::CavalrySaber" />
 			<Item Stack="1" Name="Cutlass" ID="classes.Items.Melee::Cutlass" />
-			<Item Stack="1" Name="E's Hmmr" ID="classes.Items.Melee::EmmysJolthammer" DisplayName="Emmy's Jolthammer" />
-			<Item Stack="1" Name="E'sSaber" ID="classes.Items.Melee::EmmysLavaSaber" DisplayName="Emmy's Lava Saber" />
-			<Item Stack="1" Name="E's Blade" ID="classes.Items.Melee::EmmysVampBlade" DisplayName="Emmy's Vamp Blade" />
+			<Item Stack="1" Name="E's Hmmr" ID="classes.Items.Melee::EmmysJolthammer" LongName="Emmy's Jolthammer" />
+			<Item Stack="1" Name="E'sSaber" ID="classes.Items.Melee::EmmysLavaSaber" LongName="Emmy's Lava Saber" />
+			<Item Stack="1" Name="E's Blade" ID="classes.Items.Melee::EmmysVampBlade" LongName="Emmy's Vamp Blade" />
 			<Item Stack="1" Name="J.Hmmr." ID="classes.Items.Melee::Jolthammer" />
 			<Item Stack="1" Name="Knife" ID="classes.Items.Melee::Knife" />
 			<Item Stack="1" Name="L.Saber" ID="classes.Items.Melee::LavaSaber" />
@@ -1172,12 +1148,12 @@
 			<Item Stack="1" Name="ArcCast." ID="classes.Items.Guns::ArcCaster" />
 			<Item Stack="1" Name="B.Light" ID="classes.Items.Guns::BlackLight" />
 			<Item Stack="1" Name="B.Rifle" ID="classes.Items.Guns::BoltActionRifle" />
-			<Item Stack="1" Name="Custom LP-17" ID="classes.Items.Guns::CustomLP17" DisplayName="Custom LP-17 Laser Pistol" />
+			<Item Stack="1" Name="Custom LP-17" ID="classes.Items.Guns::CustomLP17" LongName="Custom LP-17 Laser Pistol" />
 			<Item Stack="1" Name="E.Handgun" ID="classes.Items.Guns::EagleHandgun" />
 			<Item Stack="1" Name="Electrogun" ID="classes.Items.Guns::Electrogun" />
-			<Item Stack="1" Name="E's Pistol" ID="classes.Items.Guns::EmmysSalamanderPistol" DisplayName="Emmy's Salamander Pistol" />
-			<Item Stack="1" Name="E's Rifle" ID="classes.Items.Guns::EmmysSalamanderRifle" DisplayName="Emmy's Salamander Rifle" />
-			<Item Stack="1" Name="E's S.R." ID="classes.Items.Guns::EmmysSalamanderRifle2" DisplayName="Emmy's Tweaked Salamander Rifle" />
+			<Item Stack="1" Name="E's Pistol" ID="classes.Items.Guns::EmmysSalamanderPistol" LongName="Emmy's Salamander Pistol" />
+			<Item Stack="1" Name="E's Rifle" ID="classes.Items.Guns::EmmysSalamanderRifle" LongName="Emmy's Salamander Rifle" />
+			<Item Stack="1" Name="E's S.R." ID="classes.Items.Guns::EmmysSalamanderRifle2" LongName="Emmy's Tweaked Salamander Rifle" />
 			<Item Stack="1" Name="FlareGun" ID="classes.Items.Guns::FlareGun" />
 			<Item Stack="1" Name="Goovolver" ID="classes.Items.Guns::Goovolver" />
 			<Item Stack="1" Name="Hammer C." ID="classes.Items.Guns::HammerCarbine" />

--- a/TiTsEd/ViewModel/CharacterVM.cs
+++ b/TiTsEd/ViewModel/CharacterVM.cs
@@ -19,8 +19,13 @@ namespace TiTsEd.ViewModel {
             Cocks = new CockArrayVM(game, GetObj("cocks"));
             Ass = new VaginaVM(game, GetObj("ass"));
 
+            List<String> types = new List<String>();
+            foreach (XmlItemType type in XmlData.Current.ItemTypes) {
+                types.Add(type.Name);
+            }
+
             var containers = new List<ItemContainerVM>();
-            _inventory = new ItemContainerVM(this, "Inventory", ItemCategories.All);
+            _inventory = new ItemContainerVM(this, "Inventory", types);
             containers.Add(_inventory);
             UpdateInventory();
 

--- a/TiTsEd/ViewModel/ItemVM.cs
+++ b/TiTsEd/ViewModel/ItemVM.cs
@@ -84,9 +84,28 @@ namespace TiTsEd.ViewModel {
                         int fieldMatch = 0;
                         foreach (XmlObjectField field in item.Fields) {
                             //field.Name
-                            if (HasValue(field.Name) && GetString(field.Name).ToLower().Equals(field.Value.ToLower())) {
-                                //field matches
-                                fieldMatch++;
+                            if (HasValue(field.Name)) {
+                                //do it by type
+                                switch (field.Type.ToLower()) {
+                                    case "bool":
+                                        if (field.Value.StartsWith("t", true, null) == GetBool(field.Name)) {
+                                            fieldMatch++;
+                                        }
+                                        break;
+                                    case "int":
+                                        if (int.Parse(field.Value) == GetInt(field.Name)) {
+                                            fieldMatch++;
+                                        }
+                                        break;
+                                    case "string":
+                                        if (field.Value == GetString(field.Name)) {
+                                            fieldMatch++;
+                                        }
+                                        break;
+                                    default:
+                                        //no match since we have no idea what type it is
+                                        break;
+                                }
                             }
                         }
                         if (fieldMatch > bestFieldMatch) {
@@ -106,16 +125,34 @@ namespace TiTsEd.ViewModel {
             TypeID = xmlItem.ID;
             if (xmlItem != XmlItem.Empty) {
                 SetValue("version", 1);
+                /* update the name as well */
+                Name = xmlItem.Name;
                 if (null != xmlItem.LongName && xmlItem.LongName.Length > 0) {
                     LongName = xmlItem.LongName;
                 }
                 if (null != xmlItem.Tooltip && xmlItem.Tooltip.Length > 0) {
                     Tooltip = xmlItem.Tooltip;
                 }
-                /*
-                if (null != xmlItem.Variant && xmlItem.Variant.Length > 0) {
-                    Variant = xmlItem.Variant;
-                }*/
+                /* Update all extra fields with fields from the xml. */
+                foreach (XmlObjectField field in xmlItem.Fields) {
+                    switch (field.Type.ToLower()) {
+                        case "bool":
+                            SetValue(field.Name, field.Value.StartsWith("t", true, null));
+                            break;
+                        case "int":
+                            SetValue(field.Name, int.Parse(field.Value));
+                            break;
+                        case "string":
+                            SetValue(field.Name, field.Value);
+                            break;
+                        default:
+                            //no match since we have no idea what type it is
+                            break;
+                    }
+                }
+
+
+                /* SetValue("quantity", value); */
                 Quantity = xmlItem.Stack;
             }
 
@@ -157,15 +194,9 @@ namespace TiTsEd.ViewModel {
             OnPropertyChanged("AllGroups");
         }
 
-        public List<String> Types {
-            get;
-            private set;
-        }
+        public List<String> Types { get; private set; }
 
-        public UpdatableCollection<ItemGroupVM> AllGroups {
-            get;
-            private set;
-        }
+        public UpdatableCollection<ItemGroupVM> AllGroups { get; private set; }
 
         public int MaxQuantity {
             get {
@@ -214,8 +245,6 @@ namespace TiTsEd.ViewModel {
         public string LongName { get; set; }
 
         public string Tooltip { get; set; }
-
-        public string Variant { get; set; }
 
         public string DisplayName {
             get {


### PR DESCRIPTION
This should fix issue #28  forever. The game will load these partial Random Properties fine and populate any missing entries with the defaults when saving from TiTs.

I also made item categories to make adding items to the xml file easier.

This also means that the editor can now detect and differentiate the difference between normal and hard light variants of two otherwise identical pair of underwear, something the game itself does not even do.

The Corny T-shirts are still and issue, but it appears to be an issue with TiTs and not TiTsEd.